### PR TITLE
benches: Switch to criterion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 
     # Make sure there are no clippy warnings
     - env: CLIPPY
-      rust: nightly
+      rust: stable
       install:
         - rustup component add clippy
       script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,14 @@ proc-macro-hack = "0.5.4"
 lexpr-macros = { version = "0.1.2", path = "lexpr-macros" }
 
 [dev-dependencies]
+criterion = "0.2"
 quickcheck = "0.8.2"
 quickcheck_macros = "0.8.0"
 rand = "0.6.5"
+
+[[bench]]
+name = "bench"
+harness = false
 
 [badges]
 travis-ci = { repository = "rotty/lexpr-rs" }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,25 +1,31 @@
-#![feature(test)]
-
-extern crate test;
-
-use test::{black_box, Bencher};
+use criterion::*;
 
 use lexpr::{from_str, from_str_custom, parse};
 
-#[bench]
-fn bench_float_parsing(b: &mut Bencher) {
-    b.iter(|| black_box(from_str("-1.360438755021694e308")));
+fn bench_float_parsing(c: &mut Criterion) {
+    c.bench_function("float parsing", |b| {
+        b.iter(|| black_box(from_str("-1.360438755021694e308")))
+    });
 }
 
-#[bench]
-fn bench_parsing_keyword_default(b: &mut Bencher) {
-    b.iter(|| black_box(from_str("#:some-keyword")))
+fn bench_parsing_keyword_default(c: &mut Criterion) {
+    c.bench_function("keyword parsing (default settings)", |b| {
+        b.iter(|| black_box(from_str("#:some-keyword")))
+    });
 }
 
-#[bench]
-fn bench_parsing_keyword_all_styles(b: &mut Bencher) {
+fn bench_parsing_keyword_all_styles(c: &mut Criterion) {
     use parse::KeywordStyle::*;
-    let options =
-        parse::Options::default().with_keyword_styles(&[ColonPrefix, ColonPostfix, Octothorpe]);
-    b.iter(|| black_box(from_str_custom("#:octo :prefix postfix:", options.clone())));
+    c.bench_function("keyword parsing (all styles)", |b| {
+        let options =
+            parse::Options::default().with_keyword_styles(&[ColonPrefix, ColonPostfix, Octothorpe]);
+        b.iter(|| black_box(from_str_custom("#:octo :prefix postfix:", options.clone())))
+    });
 }
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = bench_float_parsing, bench_parsing_keyword_default, bench_parsing_keyword_all_styles
+}
+criterion_main!(benches);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -137,6 +137,7 @@ fn write_parse_number(input: Number) -> bool {
 #[test]
 fn write_number() {
     let mut bytes = Vec::new();
+    #[allow(clippy::unreadable_literal)]
     Number::from(-11.287888289184039)
         .write(&mut bytes)
         .expect("conversion to bytes failed");


### PR DESCRIPTION
This allows for running the benchmarks on stable, and thus we can also
use clippy from stable.