### PR TITLE
Optimize value representation

### DIFF
--- a/lexpr/src/tests.rs
+++ b/lexpr/src/tests.rs
@@ -34,15 +34,15 @@ fn gen_value<G: Gen>(g: &mut G, depth: usize) -> Value {
         Number => Value::Number(Arbitrary::arbitrary(g)),
         String => {
             let choices = ["", "foo", "\"", "\t"];
-            Value::String(choices.choose(g).unwrap().to_string())
+            Value::string(*choices.choose(g).unwrap())
         }
         Symbol => {
             let choices = ["foo", "a-symbol", "$?:!"];
-            Value::Symbol(choices.choose(g).unwrap().to_string())
+            Value::symbol(*choices.choose(g).unwrap())
         }
         Keyword => {
             let choices = ["foo", "a-keyword", "$?:!"];
-            Value::Keyword(choices.choose(g).unwrap().to_string())
+            Value::keyword(*choices.choose(g).unwrap())
         }
         Cons => Value::from((gen_value(g, depth + 1), gen_value(g, depth + 1))),
     }

--- a/lexpr/src/value/from.rs
+++ b/lexpr/src/value/from.rs
@@ -29,14 +29,21 @@ impl From<&str> for Value {
 impl<'a> From<Cow<'a, str>> for Value {
     #[inline]
     fn from(s: Cow<'a, str>) -> Self {
-        Value::from(s.to_string())
+        Value::from(s.as_ref())
+    }
+}
+
+impl From<Box<str>> for Value {
+    #[inline]
+    fn from(s: Box<str>) -> Self {
+        Value::String(s)
     }
 }
 
 impl From<String> for Value {
     #[inline]
     fn from(s: String) -> Self {
-        Value::String(s)
+        Value::String(s.into_boxed_str())
     }
 }
 

--- a/lexpr/src/value/mod.rs
+++ b/lexpr/src/value/mod.rs
@@ -142,13 +142,13 @@ pub enum Value {
     Number(Number),
 
     /// A string.
-    String(String),
+    String(Box<str>),
 
     /// A symbol.
-    Symbol(String),
+    Symbol(Box<str>),
 
     /// A keyword.
-    Keyword(String),
+    Keyword(Box<str>),
 
     /// Represents a Lisp "cons cell".
     ///
@@ -163,7 +163,7 @@ pub enum Value {
 
 impl Value {
     /// Construct a symbol, given its name.
-    pub fn symbol(name: impl Into<String>) -> Self {
+    pub fn symbol(name: impl Into<Box<str>>) -> Self {
         Value::Symbol(name.into())
     }
 
@@ -175,7 +175,7 @@ impl Value {
     /// assert!(value.is_keyword());
     /// assert_eq!(value.as_name().unwrap(), "foo");
     /// ```
-    pub fn keyword(name: impl Into<String>) -> Self {
+    pub fn keyword(name: impl Into<Box<str>>) -> Self {
         Value::Keyword(name.into())
     }
 
@@ -187,7 +187,7 @@ impl Value {
     /// assert!(value.is_string());
     /// assert_eq!(value.as_str().unwrap(), "foo");
     /// ```
-    pub fn string(s: impl Into<String>) -> Self {
+    pub fn string(s: impl Into<Box<str>>) -> Self {
         Value::String(s.into())
     }
 

--- a/serde-lexpr/src/value/ser.rs
+++ b/serde-lexpr/src/value/ser.rs
@@ -64,11 +64,13 @@ impl ser::Serializer for Serializer {
     }
 
     fn serialize_char(self, value: char) -> Result<Value> {
-        Ok(Value::String(value.to_string()))
+        // TODO: Add char type
+        use std::iter::FromIterator;
+        Ok(Value::String(String::from_iter(&[value]).into_boxed_str()))
     }
 
     fn serialize_str(self, value: &str) -> Result<Value> {
-        Ok(Value::String(value.to_owned()))
+        Ok(Value::String(value.into()))
     }
 
     fn serialize_bytes(self, _value: &[u8]) -> Result<Value> {


### PR DESCRIPTION
As we do not expect frequent in-line modification of strings, symbols
and keywords, let's cut down the size of the `Value` type by using
`Box<str>` instead of `String`.