### PR TITLE
Adjust rules regarding escaping in strings

### DIFF
--- a/lexpr/src/parse/error.rs
+++ b/lexpr/src/parse/error.rs
@@ -108,9 +108,6 @@ pub(crate) enum ErrorCode {
     /// Invalid unicode code point.
     InvalidUnicodeCodePoint,
 
-    /// Control character found while parsing a string.
-    ControlCharacterWhileParsingString,
-
     /// S-expression has non-whitespace trailing characters after the value.
     TrailingCharacters,
 
@@ -132,9 +129,6 @@ impl Display for ErrorCode {
             ErrorCode::InvalidNumber => f.write_str("invalid number"),
             ErrorCode::MismatchedParenthesis => f.write_str("mismatched parenthesis"),
             ErrorCode::NumberOutOfRange => f.write_str("number out of range"),
-            ErrorCode::ControlCharacterWhileParsingString => {
-                f.write_str("control character while parsing string")
-            }
             ErrorCode::InvalidUnicodeCodePoint => f.write_str("invalid unicode code point"),
             ErrorCode::TrailingCharacters => f.write_str("trailing characters"),
             ErrorCode::RecursionLimitExceeded => f.write_str("recursion limit exceeded"),

--- a/lexpr/src/parse/tests.rs
+++ b/lexpr/src/parse/tests.rs
@@ -55,8 +55,16 @@ where
     assert!(parse(r#""\x00110000;""#).is_err());
     assert_eq!(parse(r#""\x000000001;""#).unwrap(), Value::string("\u{01}"));
     assert!(parse(r#""\xD800;""#).is_err());
+
     // Check that u32 overflow is detected
     assert!(parse(r#""\x100000001;""#).is_err());
+
+    // Check that raw control characters are accepted
+    let control_chars: String = (0..32).map(char::from).collect();
+    assert_eq!(
+        parse(&format!("\"{}\"", control_chars)).unwrap(),
+        Value::from(control_chars)
+    );
 }
 
 #[test]


### PR DESCRIPTION
In Lisps, generally only `"` and `\` need escaping; this seems to be
true of all of R6RS/R7RS, Emacs Lisp and Common Lisp.