### PR TITLE
Initial support for byte vectors

### DIFF
--- a/lexpr-macros/src/generator.rs
+++ b/lexpr-macros/src/generator.rs
@@ -27,7 +27,7 @@ impl ToTokens for Value {
                 _ => quote! { ::lexpr::Value::append(vec![#(#elements),*], #rest) },
             },
             Value::Vector(elements) => quote! {
-                ::lexpr::Value::from(vec![#(#elements),*])
+                ::lexpr::Value::Vector(vec![#(#elements),*].into())
             },
         };
         tokens.extend(expanded);

--- a/lexpr/TODO.md
+++ b/lexpr/TODO.md
@@ -6,7 +6,7 @@
 - [ ] Syntactic sugar for quote, quasiquote, unquote and unquote-splicing
 - [ ] Support for characters
 - [X] Support for vectors
-- [ ] Support for byte vectors
+- [X] Support for byte vectors
 - [ ] Pretty-printing
 
 ## The `sexp` Macro

--- a/lexpr/src/lib.rs
+++ b/lexpr/src/lib.rs
@@ -220,6 +220,16 @@
 //! #(1 2 "three") ; A vector in Scheme notation
 //! ```
 //!
+//! ## Byte vectors
+//!
+//! Byte vectors are similar to regular vectors, but are uniform: each element
+//! only holds a single byte, i.e. an exact integer in the range of 0 to 255,
+//! inclusive.
+//!
+//! ```scheme
+//! #u8(41 42 43) ; A byte vector
+//! ```
+//!
 //! [Serde]: https://crates.io/crates/serde
 //! [`serde-lexpr`]: https://docs.rs/serde-lexpr
 

--- a/lexpr/src/parse/error.rs
+++ b/lexpr/src/parse/error.rs
@@ -96,6 +96,12 @@ pub(crate) enum ErrorCode {
     /// Expected this character to start an S-expression value.
     ExpectedSomeValue,
 
+    /// Expected a vector.
+    ExpectedVector,
+
+    /// Expected an octet (integer in range 0-255).
+    ExpectedOctet,
+
     /// Invalid hex escape code.
     InvalidEscape,
 
@@ -125,6 +131,8 @@ impl Display for ErrorCode {
             ErrorCode::EofWhileParsingValue => f.write_str("EOF while parsing a value"),
             ErrorCode::ExpectedSomeIdent => f.write_str("expected ident"),
             ErrorCode::ExpectedSomeValue => f.write_str("expected value"),
+            ErrorCode::ExpectedVector => f.write_str("expected vector"),
+            ErrorCode::ExpectedOctet => f.write_str("expected octet"),
             ErrorCode::InvalidEscape => f.write_str("invalid escape"),
             ErrorCode::InvalidNumber => f.write_str("invalid number"),
             ErrorCode::MismatchedParenthesis => f.write_str("mismatched parenthesis"),

--- a/lexpr/src/parse/tests.rs
+++ b/lexpr/src/parse/tests.rs
@@ -151,3 +151,11 @@ fn test_list_elisp() {
         Value::list(vec![Value::Null])
     );
 }
+
+#[test]
+fn test_byte_vectors() {
+    assert_eq!(from_str("#u8(1 2 3)").unwrap(), Value::from(vec![1, 2, 3]));
+    for input in &["#u8(0 256 3)", "#u8(0.0 1 2)", "#u8(test 1 2)"] {
+        assert!(from_str(input).is_err());
+    }
+}

--- a/lexpr/src/tests.rs
+++ b/lexpr/src/tests.rs
@@ -17,6 +17,7 @@ enum ValueKind {
     String,
     Symbol,
     Keyword,
+    Bytes,
     Cons,
     Vector,
 }
@@ -24,10 +25,10 @@ enum ValueKind {
 fn gen_value<G: Gen>(g: &mut G, depth: usize) -> Value {
     use ValueKind::*;
     let choices = if depth >= g.size() {
-        &[Nil, Null, Bool, Number, String, Symbol, Keyword] as &[ValueKind]
+        &[Nil, Null, Bool, Number, String, Symbol, Keyword, Bytes] as &[ValueKind]
     } else {
         &[
-            Nil, Null, Bool, Number, String, Symbol, Keyword, Cons, Vector,
+            Nil, Null, Bool, Number, String, Symbol, Keyword, Bytes, Cons, Vector,
         ]
     };
     match choices.choose(g).unwrap() {
@@ -46,6 +47,10 @@ fn gen_value<G: Gen>(g: &mut G, depth: usize) -> Value {
         Keyword => {
             let choices = ["foo", "a-keyword", "$?:!"];
             Value::keyword(*choices.choose(g).unwrap())
+        }
+        Bytes => {
+            let choices = [b"".as_ref(), b"\x01\x02\x03", b"Hello World\x00"];
+            Value::Bytes(choices.choose(g).map(|&bytes| bytes.into()).unwrap())
         }
         Cons => Value::from((gen_value(g, depth + 1), gen_value(g, depth + 1))),
         Vector => {

--- a/lexpr/src/value/from.rs
+++ b/lexpr/src/value/from.rs
@@ -54,6 +54,27 @@ impl From<bool> for Value {
     }
 }
 
+impl From<&[u8]> for Value {
+    #[inline]
+    fn from(bytes: &[u8]) -> Self {
+        Value::Bytes(bytes.into())
+    }
+}
+
+impl From<Box<[u8]>> for Value {
+    #[inline]
+    fn from(bytes: Box<[u8]>) -> Self {
+        Value::Bytes(bytes)
+    }
+}
+
+impl From<Vec<u8>> for Value {
+    #[inline]
+    fn from(bytes: Vec<u8>) -> Self {
+        Value::Bytes(bytes.into_boxed_slice())
+    }
+}
+
 impl From<Number> for Value {
     fn from(n: Number) -> Self {
         Value::Number(n)

--- a/lexpr/src/value/mod.rs
+++ b/lexpr/src/value/mod.rs
@@ -150,6 +150,9 @@ pub enum Value {
     /// A keyword.
     Keyword(Box<str>),
 
+    /// A byte vector.
+    Bytes(Box<[u8]>),
+
     /// Represents a Lisp "cons cell".
     ///
     /// Cons cells are often used to form singly-linked lists.

--- a/serde-lexpr/Cargo.toml
+++ b/serde-lexpr/Cargo.toml
@@ -16,3 +16,4 @@ serde = "1.0.89"
 
 [dev-dependencies]
 serde_derive = "1.0.89"
+serde_bytes = "0.10"

--- a/serde-lexpr/src/value/ser.rs
+++ b/serde-lexpr/src/value/ser.rs
@@ -73,8 +73,8 @@ impl ser::Serializer for Serializer {
         Ok(Value::String(value.into()))
     }
 
-    fn serialize_bytes(self, _value: &[u8]) -> Result<Value> {
-        unimplemented!()
+    fn serialize_bytes(self, value: &[u8]) -> Result<Value> {
+        Ok(Value::Bytes(value.into()))
     }
 
     fn serialize_unit(self) -> Result<Value> {

--- a/serde-lexpr/tests/value-serde.rs
+++ b/serde-lexpr/tests/value-serde.rs
@@ -24,6 +24,15 @@ fn test_int() {
 }
 
 #[test]
+fn test_bytes() {
+    let bytes = b"abc";
+    test_serde(
+        &serde_bytes::ByteBuf::from(bytes.as_ref()),
+        &Value::from(&bytes[..]),
+    );
+}
+
+#[test]
 fn test_vec() {
     let empty: Vec<u32> = vec![];
     test_serde(&empty, &sexp!(()));


### PR DESCRIPTION
Parsing Emacs Lisp unibyte strings is missing, and will be added in
another commit.