### PR TITLE
Initial support for characters

### DIFF
--- a/lexpr/README.md
+++ b/lexpr/README.md
@@ -55,16 +55,12 @@ common across dialects, are not yet implemented:
 
 - Comments. These are not high-priority, as the primary use-case for
   `lexpr` is for data exchange between Lisp and Rust programs.
-- Characters.
 - Syntactic shorthands for `quote`, `quasiquote`, `unquote` and
   `unquote-splicing`. Again, these are not usually important when
   using S-expressions as a data exchange format.
 - Support for number syntax is currently quite limited. Integers and
   floating point values written in decimal notation should work
   though.
-
-It is planned to add at least a character data type before the 0.2.0
-release, as this addition will be API-breaking.
 
 Further dialect-specific omissions, both ones that are planned to be
 fixed in the future, and deliberate ones, are listed below.

--- a/lexpr/TODO.md
+++ b/lexpr/TODO.md
@@ -4,7 +4,7 @@
 - [X] Proper string escape syntax, instead of using JSON's rules
 - [X] Serde support
 - [ ] Syntactic sugar for quote, quasiquote, unquote and unquote-splicing
-- [ ] Support for characters
+- [X] Support for characters
 - [X] Support for vectors
 - [X] Support for byte vectors
 - [ ] Pretty-printing

--- a/lexpr/src/lib.rs
+++ b/lexpr/src/lib.rs
@@ -173,6 +173,11 @@
 //! 1 -4 3.14 ; A postive, negative, and a floating point number
 //! ```
 //!
+//! ### Characters
+//!
+//! Characters are unicode codepoints, represented by Rust's char data type
+//! embedded in the [`Value::Char`] variant.
+//!
 //! ### Strings
 //!
 //! ```scheme
@@ -267,6 +272,19 @@ use proc_macro_hack::proc_macro_hack;
 /// assert!(kebab_sym.is_symbol());
 /// assert!(kebab_kw.is_keyword());
 /// ```
+///
+/// # Characters
+///
+/// Characters can be written using Rust's character syntax:
+///
+/// ```
+/// # use lexpr::sexp;
+///
+/// let ch = sexp!('λ');
+/// assert!(ch.is_char());
+/// assert_eq!(ch.as_char(), Some('λ'));
+/// ```
+///
 /// # Lists
 ///
 /// Lists can be formed by using the same syntax as in Lisp, including dot

--- a/lexpr/src/parse/error.rs
+++ b/lexpr/src/parse/error.rs
@@ -87,6 +87,9 @@ pub(crate) enum ErrorCode {
     /// EOF while parsing a S-expression value.
     EofWhileParsingValue,
 
+    // EOF while parsing character constant.
+    EofWhileParsingCharacterConstant,
+
     /// Expected to parse either a `#t`, `#f`, or a `#nil`.
     ExpectedSomeIdent,
 
@@ -114,6 +117,9 @@ pub(crate) enum ErrorCode {
     /// Invalid unicode code point.
     InvalidUnicodeCodePoint,
 
+    /// Invalid character constant.
+    InvalidCharacterConstant,
+
     /// S-expression has non-whitespace trailing characters after the value.
     TrailingCharacters,
 
@@ -129,6 +135,9 @@ impl Display for ErrorCode {
             ErrorCode::EofWhileParsingVector => f.write_str("EOF while parsing a vector"),
             ErrorCode::EofWhileParsingString => f.write_str("EOF while parsing a string"),
             ErrorCode::EofWhileParsingValue => f.write_str("EOF while parsing a value"),
+            ErrorCode::EofWhileParsingCharacterConstant => {
+                f.write_str("EOF while parsing a character constant")
+            }
             ErrorCode::ExpectedSomeIdent => f.write_str("expected ident"),
             ErrorCode::ExpectedSomeValue => f.write_str("expected value"),
             ErrorCode::ExpectedVector => f.write_str("expected vector"),
@@ -138,6 +147,7 @@ impl Display for ErrorCode {
             ErrorCode::MismatchedParenthesis => f.write_str("mismatched parenthesis"),
             ErrorCode::NumberOutOfRange => f.write_str("number out of range"),
             ErrorCode::InvalidUnicodeCodePoint => f.write_str("invalid unicode code point"),
+            ErrorCode::InvalidCharacterConstant => f.write_str("invalid character constant"),
             ErrorCode::TrailingCharacters => f.write_str("trailing characters"),
             ErrorCode::RecursionLimitExceeded => f.write_str("recursion limit exceeded"),
         }

--- a/lexpr/src/parse/tests.rs
+++ b/lexpr/src/parse/tests.rs
@@ -28,6 +28,32 @@ fn test_atom_failures() {
     assert!(from_str_custom("#:octothorpe-keyword", Options::new()).is_err());
 }
 
+#[test]
+fn test_chars_default() {
+    for &c in &['x', 'y', 'z', '\u{203D}', ' '] {
+        assert_eq!(from_str(&format!("#\\{}", c)).unwrap(), Value::Char(c));
+    }
+    for &(name, code) in &[
+        ("nul", 0x00),
+        ("alarm", 0x07),
+        ("backspace", 0x08),
+        ("tab", 0x09),
+        ("linefeed", 0x0A),
+        ("newline", 0x0A),
+        ("vtab", 0x0B),
+        ("page", 0x0C),
+        ("return", 0x0D),
+        ("esc", 0x1B),
+        ("space", 0x20),
+        ("delete", 0x7F),
+    ] {
+        assert_eq!(
+            from_str(&format!("#\\{}", name)).unwrap(),
+            Value::Char(char::from(code))
+        );
+    }
+}
+
 // This is generic over the parser to allow testing both the slice-based and
 // I/O-based `Read` trait implementations.
 fn check_strings_default<F>(parse: F)

--- a/lexpr/src/tests.rs
+++ b/lexpr/src/tests.rs
@@ -14,6 +14,7 @@ enum ValueKind {
     Null,
     Bool,
     Number,
+    Char,
     String,
     Symbol,
     Keyword,
@@ -25,10 +26,12 @@ enum ValueKind {
 fn gen_value<G: Gen>(g: &mut G, depth: usize) -> Value {
     use ValueKind::*;
     let choices = if depth >= g.size() {
-        &[Nil, Null, Bool, Number, String, Symbol, Keyword, Bytes] as &[ValueKind]
+        &[
+            Nil, Null, Bool, Number, Char, String, Symbol, Keyword, Bytes,
+        ] as &[ValueKind]
     } else {
         &[
-            Nil, Null, Bool, Number, String, Symbol, Keyword, Bytes, Cons, Vector,
+            Nil, Null, Bool, Number, Char, String, Symbol, Keyword, Bytes, Cons, Vector,
         ]
     };
     match choices.choose(g).unwrap() {
@@ -36,6 +39,7 @@ fn gen_value<G: Gen>(g: &mut G, depth: usize) -> Value {
         Null => Value::Null,
         Bool => Value::Bool(g.gen()),
         Number => Value::Number(Arbitrary::arbitrary(g)),
+        Char => Value::Char(Arbitrary::arbitrary(g)),
         String => {
             let choices = ["", "foo", "\"", "\t"];
             Value::string(*choices.choose(g).unwrap())

--- a/lexpr/src/value/from.rs
+++ b/lexpr/src/value/from.rs
@@ -19,6 +19,13 @@ macro_rules! impl_from_number {
 
 impl_from_number!(u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
 
+impl From<char> for Value {
+    #[inline]
+    fn from(c: char) -> Self {
+        Value::Char(c)
+    }
+}
+
 impl From<&str> for Value {
     #[inline]
     fn from(s: &str) -> Self {

--- a/lexpr/src/value/mod.rs
+++ b/lexpr/src/value/mod.rs
@@ -141,6 +141,9 @@ pub enum Value {
     /// A number.
     Number(Number),
 
+    /// A character.
+    Char(char),
+
     /// A string.
     String(Box<str>),
 
@@ -631,6 +634,31 @@ impl Value {
     pub fn as_bool(&self) -> Option<bool> {
         match self {
             Value::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    /// Returns true if the value is a character. Returns false otherwise.
+    pub fn is_char(&self) -> bool {
+        self.as_char().is_some()
+    }
+
+    /// If the value is a character, returns the associated `char`. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use lexpr::sexp;
+    /// #
+    /// let v = sexp!(((a . 'c') (b . "c")));
+    ///
+    /// assert_eq!(v["a"].as_char(), Some('c'));
+    ///
+    /// // The string `"c"` is a single-character string, not a character.
+    /// assert_eq!(v["b"].as_char(), None);
+    /// ```
+    pub fn as_char(&self) -> Option<char> {
+        match self {
+            Value::Char(c) => Some(*c),
             _ => None,
         }
     }

--- a/lexpr/src/value/tests.rs
+++ b/lexpr/src/value/tests.rs
@@ -9,6 +9,7 @@ static TYPE_PREDICATES: &[(&'static str, Predicate)] = &[
     ("keyword", Value::is_keyword),
     ("nil", Value::is_nil),
     ("number", Value::is_number),
+    ("char", Value::is_char),
     ("list", Value::is_list),
     ("vector", Value::is_vector),
 ];
@@ -79,6 +80,15 @@ fn test_numbers() {
         check_type_predicates(&n_value, "number");
         assert_eq!(n_value.as_number(), Some(n));
         assert_eq!(n_value.as_name(), None);
+    }
+}
+
+#[test]
+fn test_chars() {
+    for &c in &['x', '\u{203D}', '\u{10FFFF}'] {
+        let c_value = Value::from(c);
+        check_type_predicates(&c_value, "char");
+        assert_eq!(c_value.as_char(), Some(c));
     }
 }
 

--- a/serde-lexpr/src/value/ser.rs
+++ b/serde-lexpr/src/value/ser.rs
@@ -64,9 +64,7 @@ impl ser::Serializer for Serializer {
     }
 
     fn serialize_char(self, value: char) -> Result<Value> {
-        // TODO: Add char type
-        use std::iter::FromIterator;
-        Ok(Value::String(String::from_iter(&[value]).into_boxed_str()))
+        Ok(Value::Char(value))
     }
 
     fn serialize_str(self, value: &str) -> Result<Value> {

--- a/serde-lexpr/tests/value-serde.rs
+++ b/serde-lexpr/tests/value-serde.rs
@@ -24,6 +24,11 @@ fn test_int() {
 }
 
 #[test]
+fn test_char() {
+    test_serde(&'c', &sexp!('c'));
+}
+
+#[test]
 fn test_bytes() {
     let bytes = b"abc";
     test_serde(


### PR DESCRIPTION
Emacs Lisp read syntax is not yet implemented; it will be added in a
later commit.