### PR TITLE
Fix string escape syntax

### DIFF
--- a/lexpr/src/parse/mod.rs
+++ b/lexpr/src/parse/mod.rs
@@ -16,7 +16,7 @@ use read::{ElispStr, Reference};
 
 use crate::{Cons, Number, Value};
 
-pub use crate::style::KeywordStyle;
+pub use crate::style::{KeywordStyle, StringSyntax};
 
 pub use read::{IoRead, Read, SliceRead, StrRead};
 
@@ -90,20 +90,6 @@ pub enum Brackets {
 
     /// Brackets indicate a vector, like in Emacs Lisp.
     Vector,
-}
-
-/// Defines the accepted syntax for strings.
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum StringSyntax {
-    /// Syntax as specified the R6RS.
-    ///
-    /// Note that there is no R7RS variant, because R6RS specifies a superset of
-    /// R7RS syntax.
-    R6RS,
-    /// Emacs Lisp syntax.
-    ///
-    /// Note that unibyte strings will be parsed as byte vectors.
-    Elisp,
 }
 
 impl Options {

--- a/lexpr/src/parse/read.rs
+++ b/lexpr/src/parse/read.rs
@@ -687,6 +687,7 @@ fn parse_r6rs_escape<'de, R: Read<'de>>(read: &mut R, scratch: &mut Vec<u8>) -> 
         b'r' => scratch.push(b'\r'),
         b't' => scratch.push(b'\t'),
         b'v' => scratch.push(0x0B),
+        b'|' => scratch.push(b'|'),
         // TODO: trailing backspace (i.e., a continuation line)
         b'x' => {
             let c = {

--- a/lexpr/src/parse/tests.rs
+++ b/lexpr/src/parse/tests.rs
@@ -93,6 +93,8 @@ where
         parse(&format!("\"{}\"", control_chars)).unwrap(),
         Value::from(control_chars)
     );
+    // Check an escaped vertical bar (pipe) is accepted
+    assert_eq!(parse(r#""foo\|bar""#).unwrap(), Value::string("foo|bar"));
 }
 
 #[test]

--- a/lexpr/src/style.rs
+++ b/lexpr/src/style.rs
@@ -31,3 +31,19 @@ impl KeywordStyle {
         }
     }
 }
+
+/// Indicates the syntax for strings.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum StringSyntax {
+    /// Syntax as specified the R6RS.
+    ///
+    /// Note that there is no R7RS variant, because R6RS specifies a superset of
+    /// R7RS syntax. When printing however, the syntax used will be restricted
+    /// to be understood by an R7RS parser.
+    R6RS,
+
+    /// Emacs Lisp syntax.
+    ///
+    /// Note that unibyte strings will be parsed as byte vectors.
+    Elisp,
+}

--- a/lexpr/src/tests.rs
+++ b/lexpr/src/tests.rs
@@ -1,3 +1,9 @@
+//! Basic sanity checking on the `Value` type.
+//!
+//! These tests primarily test the round-trip (i.e converting to text and back)
+//! behavior of `Value` using quickcheck. Note these do not test Emacs Lisp
+//! syntax, as it is not round-trip safe for all values tested here.
+
 use quickcheck::{Arbitrary, Gen, QuickCheck, StdGen};
 use quickcheck_macros::quickcheck;
 use rand::{seq::SliceRandom, Rng};
@@ -41,7 +47,7 @@ fn gen_value<G: Gen>(g: &mut G, depth: usize) -> Value {
         Number => Value::Number(Arbitrary::arbitrary(g)),
         Char => Value::Char(Arbitrary::arbitrary(g)),
         String => {
-            let choices = ["", "foo", "\"", "\t"];
+            let choices = ["", "foo", "\"", "\t", "\x01"];
             Value::string(*choices.choose(g).unwrap())
         }
         Symbol => {

--- a/lexpr/tests/print-parse.rs
+++ b/lexpr/tests/print-parse.rs
@@ -44,6 +44,11 @@ fn test_improper_lists() {
 }
 
 #[test]
+fn test_strings_elisp() {
+    check_roundtrip_elisp(sexp!("\x01\x02\x03\x7F"), r#""\u0001\u0002\u0003\u007F""#);
+}
+
+#[test]
 fn test_vectors() {
     check_roundtrip_default(sexp!(#()), "#()");
     check_roundtrip_default(sexp!(#(1 2 3 4)), "#(1 2 3 4)");


### PR DESCRIPTION
- This fixes the escaping for both R6RS and Emacs Lisp when printing;
  it was still using unadapted code inherited from `serde-json`.

- The `CharEscape` enum now only contains the subset of memnonic
  escapes understood by all of R6RS, R7RS and Emacs Lisp.

- Accept an escaped pipe, which is valid in both R6RS and R7RS.