### PR TITLE
travis: Set up code coverage check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+ignore:
+  - "lexpr-macros" # proc-macros don't show up in coverage, so ignore
+  - "lexpr/tests" # we also don't care about coverage of test code
+  - "serde-lexpr/tests"
+  - "lexpr/benches" # or coverage of benchmarks
+  - "serde-lexpr/benches"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,52 @@
 language: rust
+cache: cargo
+rust:
+  - 1.32.0 # uniform paths
+  - stable
+  - beta
+  - nightly
+os: linux
 
-matrix:
-  include:
-    - rust: stable
-    - rust: beta
+# always test things that aren't pushes (like PRs)
+# never test tags or pushes to non-master branches (wait for PR)
+# https://github.com/travis-ci/travis-ci/issues/2200#issuecomment-441395545)
+if: type != push OR (tag IS blank AND branch = master)
+
+jobs:
+  allow_failures:
     - rust: nightly
-
-    # Catch code formatting issues
-    - env: RUSTFMT
+  fast_finish: true
+  include:
+    - stage: check # do a pre-screen to make sure this is even worth testing
+      script: cargo check --all-targets
       rust: stable
+    # We lint using rustfmt and clippy on beta, to future-proof
+    - stage: lint
+      name: "Rust: beta, rustfmt"
+      rust: beta
       install:
         - rustup component add rustfmt
       script:
-        - cargo fmt -- --check
-
-    # Make sure there are no clippy warnings
-    - env: CLIPPY
-      rust: stable
+        - cargo fmt -v -- --check
+    - name: "Rust: beta, clippy"
+      rust: beta
       install:
         - rustup component add clippy
       script:
         - cargo clippy --all-features --all-targets -- -D warnings
+    - stage: coverage
+      sudo: required
+      dist: xenial
+      cache: false
+      services:
+        - docker
+      script:
+        - docker run --security-opt seccomp=unconfined -v "$PWD:/volume" xd009642/tarpaulin:develop-nightly sh -c "cargo tarpaulin --all --out Xml  --run-types Tests Doctests"
+        - bash <(curl -s https://codecov.io/bash)
 
-  allow_failures:
-    - rust: nightly
-  fast_finish: true
+stages:
+  - check
+  - test
+  - lint
+  - coverage
 
-branches:
-  only:
-    - master
-
-cache:
-  cargo: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# lexpr: S-expressions for Rust [![Build Status]][travis]
+# lexpr: S-expressions for Rust [![Build Status]][travis] [![Codecov]][codecov] [![Rustc Version 1.32+]][rustc]
 
 [Build Status]: https://api.travis-ci.org/rotty/lexpr-rs.svg?branch=master
 [travis]: https://travis-ci.org/rotty/lexpr-rs
+[codecov]: https://codecov.io/github/rotty/lexpr-rs/coverage.svg?branch=master
+[rustc]: https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html
 
 This repositories hosts the following crates:
 

--- a/lexpr/Cargo.toml
+++ b/lexpr/Cargo.toml
@@ -33,3 +33,4 @@ harness = false
 
 [badges]
 travis-ci = { repository = "rotty/lexpr-rs" }
+codecov = { repository = "rotty/lexpr-rs", branch = "master", service = "github" }

--- a/lexpr/src/value/mod.rs
+++ b/lexpr/src/value/mod.rs
@@ -319,7 +319,7 @@ impl Value {
         I: IntoIterator,
         I::Item: Into<Value>,
     {
-        let v: Vec<_> = elements.into_iter().map(|e| e.into()).collect();
+        let v: Vec<_> = elements.into_iter().map(Into::into).collect();
         Value::Vector(v.into_boxed_slice())
     }
 

--- a/serde-lexpr/Cargo.toml
+++ b/serde-lexpr/Cargo.toml
@@ -17,3 +17,7 @@ serde = "1.0.89"
 [dev-dependencies]
 serde_derive = "1.0.89"
 serde_bytes = "0.10"
+
+[badges]
+travis-ci = { repository = "rotty/lexpr-rs" }
+codecov = { repository = "rotty/lexpr-rs", branch = "master", service = "github" }

--- a/serde-lexpr/src/value/de.rs
+++ b/serde-lexpr/src/value/de.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use serde::de::{self, Error as _, Visitor};
+use serde::de::{self, Error as SerdeError, Visitor};
 use serde::Deserialize;
 
 use lexpr::{number, Cons, Number};


### PR DESCRIPTION
- Run tests on Rust 1.32.0 as well, so we don't accidentially break
  there.
- Run code coverage analysis using `cargo-tarpaulin` and codecov.io.