### PR TITLE
Remove Error `description()` method implementations

### DIFF
--- a/lexpr/src/parse/error.rs
+++ b/lexpr/src/parse/error.rs
@@ -268,16 +268,6 @@ impl Display for ErrorCode {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        match self.err.code {
-            ErrorCode::Io(ref err) => error::Error::description(err),
-            _ => {
-                // If you want a better message, use Display::fmt or to_string().
-                "S-expression error"
-            }
-        }
-    }
-
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self.err.code {
             ErrorCode::Io(ref err) => Some(err),

--- a/serde-lexpr/src/error.rs
+++ b/serde-lexpr/src/error.rs
@@ -114,14 +114,6 @@ impl From<Error> for io::Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        match &*self.0 {
-            ErrorImpl::Message(msg, _) => msg,
-            ErrorImpl::Io(e) => e.description(),
-            ErrorImpl::Parse(e) => e.description(),
-        }
-    }
-
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match &*self.0 {
             ErrorImpl::Io(e) => Some(e),


### PR DESCRIPTION
The standard library documentation on
`std::error::Error::description()` notes:

  This method is soft-deprecated.

  Although using it won’t cause compilation warning, new code should
  use Display instead and new impls can omit it.

Thus let's just not implement it, as new code should not use it, and
any code using `lexpr` is by definition, given its youth, quite new.