### PR TITLE
Tweak the README files a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ under the [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE)
 license, at your choosing.
 
 The `lexpr` repository contains code and documentation adapted from
-the following projects:
+the following projects, all licensed under the same conditions,
+i.e. dual-licensed under MIT or Apache-2.0 license:
 
-- [`serde_json`](https://github.com/serde-rs/json), also dual-licensed
-  under MIT/Apache-2.0 licenses.
+- [`serde_json`](https://github.com/serde-rs/json)
+- [`serde_yaml`](https://github.com/dtolnay/serde-yaml)
 - [`sexpr`](https://github.com/zv/sexpr), Copyright 2017 Zephyr
-  Pellerin, dual-licensed under the same licenses.
+  Pellerin.

--- a/lexpr/README.md
+++ b/lexpr/README.md
@@ -13,6 +13,7 @@ lexpr = "0.1.3"
 You may be looking for:
 
 - [API Documentation](https://docs.rs/crate/lexpr/)
+- [API Documentation for master branch](https://rotty.github.io/lexpr-rs/master/lexpr/)
 - [Serde support for S-expressions](https://github.com/rotty/lexpr-rs/serde-lexpr)
 - [TODO](./TODO.md)
 - [Goals and a survey of other S-expression crates](./docs/why.md)

--- a/serde-lexpr/README.md
+++ b/serde-lexpr/README.md
@@ -10,6 +10,10 @@
 serde-lexpr = { git = 'https://github.com/rotty/lexpr-rs' }
 ```
 
+You may be looking for:
+
+- [API Documentation for master branch](https://rotty.github.io/lexpr-rs/master/serde_lexpr/)
+
 This crate is a Rust library for using the [Serde] serialization
 framework with data in [S-expression] format, which are the
 human-readable, textual representation of code and data in the Lisp


### PR DESCRIPTION
- Add links to master API docs.
- Reference `serde_yaml` from top-level README.