### PR TITLE
Update dependencies

### DIFF
--- a/lexpr-macros/Cargo.toml
+++ b/lexpr-macros/Cargo.toml
@@ -11,6 +11,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "0.4"
+proc-macro2 = "1.0"
 proc-macro-hack = "0.5.4"
-quote = "0.6"
+quote = "1.0"

--- a/lexpr/Cargo.toml
+++ b/lexpr/Cargo.toml
@@ -22,10 +22,10 @@ proc-macro-hack = "0.5.4"
 lexpr-macros = { version = "0.2.0", path = "../lexpr-macros" }
 
 [dev-dependencies]
-criterion = "0.2"
-quickcheck = "0.8.2"
+criterion = "0.3.0"
+quickcheck = "0.9.0"
 quickcheck_macros = "0.8.0"
-rand = "0.6.5"
+rand = "0.7.0"
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
New versions have been released for `proc-macro2`, `quote`,
`criterion`, `quickcheck`, and `rand`.

No code changes were necessary.