### PR TITLE
Eliminate `main`-like functions from doctests

### DIFF
--- a/lexpr-macros/src/lib.rs
+++ b/lexpr-macros/src/lib.rs
@@ -1,6 +1,7 @@
 //! Internal crate implementing macros exposed by the `lexpr` crate.
 
 #![recursion_limit = "128"]
+#![warn(rust_2018_idioms)]
 
 extern crate proc_macro;
 

--- a/lexpr/src/cons.rs
+++ b/lexpr/src/cons.rs
@@ -29,7 +29,7 @@ pub struct Cons {
 }
 
 impl fmt::Debug for Cons {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "({:?} . {:?})", self.car(), self.cdr())
     }
 }
@@ -111,7 +111,7 @@ impl Cons {
     ///    println!("list element: {}", cell.car());
     /// }
     /// ```
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         Iter { cursor: Some(self) }
     }
 

--- a/lexpr/src/lib.rs
+++ b/lexpr/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![warn(rust_2018_idioms)]
 
 //! This crate provides facilities for parsing, printing and
 //! manipulating S-expression data. S-expressions are the format used

--- a/lexpr/src/lib.rs
+++ b/lexpr/src/lib.rs
@@ -66,24 +66,20 @@
 //! ```
 //!  use lexpr::{Value, parse::Error};
 //!
-//!  fn example() -> Result<(), Error> {
-//!      // Some s-expressions a &str.
-//!      let data = r#"((name . "John Doe")
-//!                     (age . 43)
-//!                     (phones "+44 1234567" "+44 2345678"))"#;
+//! # fn main() -> Result<(), Error> {
+//! // Some s-expressions a &str.
+//! let data = r#"((name . "John Doe")
+//!                (age . 43)
+//!                (phones "+44 1234567" "+44 2345678"))"#;
 //!
-//!      // Parse the string of data into lexpr::Value.
-//!      let v = lexpr::from_str(data)?;
+//! // Parse the string of data into lexpr::Value.
+//! let v = lexpr::from_str(data)?;
 //!
-//!      // Access parts of the data by indexing with square brackets.
-//!      println!("Please call {} at the number {}", v["name"], v["phones"][1]);
+//! // Access parts of the data by indexing with square brackets.
+//! println!("Please call {} at the number {}", v["name"], v["phones"][1]);
 //!
-//!      Ok(())
-//!  }
-//!  #
-//!  # fn main() {
-//!  #     example().unwrap();
-//!  # }
+//! Ok(())
+//! # }
 //! ```
 //!
 //! # What are S-expressions?

--- a/lexpr/src/number.rs
+++ b/lexpr/src/number.rs
@@ -285,7 +285,7 @@ impl From<f64> for Number {
 }
 
 impl Display for Number {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.n {
             N::PosInt(i) => Display::fmt(&i, formatter),
             N::NegInt(i) => Display::fmt(&i, formatter),
@@ -295,7 +295,7 @@ impl Display for Number {
 }
 
 impl Debug for Number {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         Debug::fmt(&self.n, formatter)
     }
 }

--- a/lexpr/src/parse/error.rs
+++ b/lexpr/src/parse/error.rs
@@ -245,7 +245,7 @@ pub(crate) enum ErrorCode {
 }
 
 impl Display for ErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ErrorCode::Io(ref err) => Display::fmt(err, f),
             ErrorCode::EofWhileParsingList => f.write_str("EOF while parsing a list"),
@@ -282,13 +282,13 @@ impl error::Error for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&*self.err, f)
     }
 }
 
 impl Display for ErrorImpl {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(loc) = self.location {
             write!(
                 f,
@@ -304,7 +304,7 @@ impl Display for ErrorImpl {
 // Remove two layers of verbosity from the debug representation. Humans often
 // end up seeing this representation because it is what unwrap() shows.
 impl Debug for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(loc) = self.err.location {
             write!(
                 f,

--- a/lexpr/src/parse/mod.rs
+++ b/lexpr/src/parse/mod.rs
@@ -1057,13 +1057,13 @@ impl<'de, R: Read<'de>> Iterator for Parser<R> {
 /// as a [`File`], you will want to apply your own buffering, e.g. using
 /// [`std::io::BufReader`].
 ///
-/// ```
+/// ```no_run
 /// use std::error::Error;
 /// use std::fs::File;
 /// use std::io::BufReader;
 /// use std::path::Path;
 ///
-/// fn read_value_from_file<P: AsRef<Path>>(path: P) -> Result<lexpr::Value, Box<Error>> {
+/// fn read_value_from_file<P: AsRef<Path>>(path: P) -> Result<lexpr::Value, Box<dyn Error>> {
 ///     // Open the file in read-only mode with buffer.
 ///     let file = File::open(path)?;
 ///     let reader = BufReader::new(file);
@@ -1075,12 +1075,8 @@ impl<'de, R: Read<'de>> Iterator for Parser<R> {
 ///     Ok(value)
 /// }
 ///
-/// fn main() {
-/// # }
-/// # fn fake_main() {
-///     let value = read_value_from_file("test.el").unwrap();
-///     println!("{:?}", value);
-/// }
+/// let value = read_value_from_file("test.el").unwrap();
+/// println!("{:?}", value);
 /// ```
 ///
 /// [`File`]: https://doc.rust-lang.org/std/fs/struct.File.html

--- a/lexpr/src/value/mod.rs
+++ b/lexpr/src/value/mod.rs
@@ -8,19 +8,17 @@
 //! ```
 //! use lexpr::sexp;
 //!
-//! fn main() {
-//!     // The type of `john` is `lexpr::Value`
-//!     let john = sexp!((
-//!         (name . "John Doe")
-//!         (age . 43)
-//!         (phones "+44 1234567" "+44 2345678")
-//!     ));
+//! // The type of `john` is `lexpr::Value`
+//! let john = sexp!((
+//!     (name . "John Doe")
+//!     (age . 43)
+//!     (phones "+44 1234567" "+44 2345678")
+//! ));
 //!
-//!     println!("first phone number: {}", john["phones"][0]);
+//! println!("first phone number: {}", john["phones"][0]);
 //!
-//!     // Convert to a string of S-expression data and print it out
-//!     println!("{}", john.to_string());
-//! }
+//! // Convert to a string of S-expression data and print it out
+//! println!("{}", john.to_string());
 //! ```
 //!
 //! The `Value::to_string()` function converts a `lexpr::Value` into a
@@ -63,28 +61,23 @@
 //! ```
 //! use lexpr::{sexp, parse::Error, Value};
 //!
-//! fn example() -> Result<(), Error> {
-//!     // Some S-expression input data as a &str. Maybe this comes from the user.
-//!     let data = r#"(
-//!             (name . "John Doe")
-//!             (age . 43)
-//!             (phones . (
-//!                 "+44 1234567"
-//!                 "+44 2345678"
-//!             ))
-//!         )"#;
+//! # fn main() -> Result<(), Error> {
+//! // Some S-expression input data as a &str. Maybe this comes from the user.
+//! let data = r#"(
+//!         (name . "John Doe")
+//!         (age . 43)
+//!         (phones . (
+//!             "+44 1234567"
+//!             "+44 2345678"
+//!         ))
+//!     )"#;
 //!
-//!     // Parse the string of data into lexpr::Value.
-//!     let v: Value = lexpr::from_str(data)?;
+//! // Parse the string of data into lexpr::Value.
+//! let v: Value = lexpr::from_str(data)?;
 //!
-//!     // Access parts of the data by indexing with square brackets.
-//!     println!("Please call {} at the number {}", v["name"], v["phones"][0]);
-//!
-//!     Ok(())
-//! }
-//! #
-//! # fn main() {
-//! #     example().unwrap();
+//! // Access parts of the data by indexing with square brackets.
+//! println!("Please call {} at the number {}", v["name"], v["phones"][0]);
+//! # Ok(())
 //! # }
 //! ```
 //!

--- a/lexpr/src/value/mod.rs
+++ b/lexpr/src/value/mod.rs
@@ -977,7 +977,7 @@ impl Value {
     }
 }
 
-struct WriterFormatter<'a, 'b: 'a> {
+struct WriterFormatter<'a, 'b> {
     inner: &'a mut fmt::Formatter<'b>,
 }
 
@@ -1013,7 +1013,7 @@ impl fmt::Display for Value {
     /// assert_eq!(compact,
     ///     r#"((city "London") (street "10 Downing Street"))"#);
     /// ```
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut wr = WriterFormatter { inner: f };
         crate::print::to_writer(&mut wr, self).map_err(|_| fmt::Error)
     }

--- a/serde-lexpr/src/error.rs
+++ b/serde-lexpr/src/error.rs
@@ -124,7 +124,7 @@ impl error::Error for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &*self.0 {
             ErrorImpl::Message(msg, _) => Display::fmt(msg, f),
             ErrorImpl::Io(e) => Display::fmt(e, f),
@@ -134,7 +134,7 @@ impl Display for Error {
 }
 
 impl Debug for Error {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &*self.0 {
             ErrorImpl::Message(msg, loc) => formatter
                 .debug_tuple("Message")
@@ -152,7 +152,7 @@ impl de::Error for Error {
         Error(Box::new(ErrorImpl::Message(msg.to_string(), None)))
     }
 
-    fn invalid_type(unexp: de::Unexpected, exp: &dyn de::Expected) -> Self {
+    fn invalid_type(unexp: de::Unexpected<'_>, exp: &dyn de::Expected) -> Self {
         if let de::Unexpected::Unit = unexp {
             Error::custom(format_args!("invalid type: null, expected {}", exp))
         } else {

--- a/serde-lexpr/src/lib.rs
+++ b/serde-lexpr/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![warn(rust_2018_idioms)]
 
 //! This crate provides [Serde]-based serialization and deserialization from
 //! statically-typed Rust data structures to S-expressions, both using the


### PR DESCRIPTION
As pointed out by the clippy lint `needless-doctest-main`, this allows
for a bit more succinct examples.