### PR TITLE
lexpr: Prepare for v0.2.4

### DIFF
--- a/lexpr-macros/Cargo.toml
+++ b/lexpr-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lexpr-macros"
 description = "Internal crate implementing macros exposed by the `lexpr` crate"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Andreas Rottmann <mail@r0tty.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rotty/lexpr-rs"

--- a/lexpr/Cargo.toml
+++ b/lexpr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lexpr"
 description = "A representation for Lisp data"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Andreas Rottmann <mail@r0tty.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rotty/lexpr-rs"

--- a/lexpr/NEWS.md
+++ b/lexpr/NEWS.md
@@ -1,3 +1,15 @@
+# 0.2.4
+
+This is dependency-update release:
+
+- The procedural `sexp` macro is now implemented on top of
+  `proc-macro2` 1.0 and `quote` 1.0.
+- `lexpr` now uses newer versions of `criterion`, `quickcheck` and
+  `rand` in its `dev-dependencies`.
+
+In addition, some minor code cleanups have been done, including slight
+simplification of some doctest examples.
+
 # 0.2.3
 
 New features:


### PR DESCRIPTION
This is accompanied by release 0.2.1 of the internal `lexpr-macros`
crate.