### PR TITLE
Travis CI: For Rust 1.32.0, only do a compilation check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+/msrv-test/target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 cache: cargo
 rust:
-  - 1.32.0 # uniform paths
   - stable
   - beta
   - nightly
@@ -21,6 +20,11 @@ jobs:
       script: cargo check --all-targets
       rust: stable
     # We lint using rustfmt and clippy on beta, to future-proof
+    - stage: test
+      name: "MSRV (1.32.0) compile check"
+      rust: 1.32.0 # uniform paths
+      script:
+        - cd msrv-test && cargo build
     - stage: lint
       name: "Rust: beta, rustfmt"
       rust: beta

--- a/lexpr-macros/src/lib.rs
+++ b/lexpr-macros/src/lib.rs
@@ -3,6 +3,8 @@
 #![recursion_limit = "128"]
 #![warn(rust_2018_idioms)]
 
+// Silence clippy, as this is still needed on Rust 1.32.0.
+#[allow(unused_extern_crates)]
 extern crate proc_macro;
 
 mod generator;

--- a/lexpr/README.md
+++ b/lexpr/README.md
@@ -48,6 +48,12 @@ To get a better idea of the direction `lexpr` is headed, you may want
 to take at the [TODO](./TODO.md) or the ["why"](./docs/why.md)
 document.
 
+## Rust version requirements
+
+`lexpr` is CI-tested on current stable, beta and nightly channels of
+Rust. Additionally, it is made sure that the code still compiles on
+Rust 1.32.0. However, no tests are run for that build.
+
 ## Supported Lisp dialects
 
 Currently, `lexpr` focuses on Scheme, mostly based on R6RS and R7RS

--- a/msrv-test/Cargo.toml
+++ b/msrv-test/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "msrv-test"
+version = "0.0.1"
+authors = ["Andreas Rottmann <a.rottmann@gmx.at>"]
+edition = "2018"
+
+[dependencies]
+lexpr = { path = "../lexpr" }
+
+[workspace]

--- a/msrv-test/src/main.rs
+++ b/msrv-test/src/main.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let data = lexpr::sexp!((#"lucky-number" . 42));
+
+    println!("data: {}", data);
+}


### PR DESCRIPTION
Since our `dev-dependencies` now require a newer Rust version, no
longer do a full test for Rust 1.32.0.