### PR TITLE
Add support number radix prefixes

### DIFF
--- a/lexpr/NEWS.md
+++ b/lexpr/NEWS.md
@@ -3,10 +3,15 @@
 New features:
 
 - The iterators for cons cell chains now have a `peek` method.
+- Number literals with R7RS radix prefixes are now understood. This
+  allows for parsing of binary, octal, hexidecimal, and
+  explicitly-decimal literals, e.g., `#b10101110`. `#o0777`,
+  `#xDEADBEEF` and `#d42`. A sign is allowed to follow the radix
+  prefix, as per R7RS formal syntax.
 
 Besides some CI churn, the `quickcheck_macros` dev-dependency has been
 updated, which eliminates old versions of `syn` and `quote` from the
-development build requirements.
+transitive development build dependencies.
 
 # 0.2.4
 

--- a/lexpr/src/parse/tests.rs
+++ b/lexpr/src/parse/tests.rs
@@ -53,12 +53,36 @@ fn test_atom_failures() {
 }
 
 #[test]
-fn test_numbers() {
+fn test_decimal_numbers() {
     assert_eq!(from_str("42").unwrap(), Value::from(42));
     assert_eq!(from_str("-23").unwrap(), Value::from(-23));
     assert_eq!(from_str("+23").unwrap(), Value::from(23));
     assert_eq!(from_str("0.5e10").unwrap(), Value::from(0.5e10));
     assert_eq!(from_str("-0.5e10").unwrap(), Value::from(-0.5e10));
+}
+
+#[test]
+fn test_hex_numbers() {
+    assert_eq!(from_str("#x42").unwrap(), Value::from(0x42));
+    assert_eq!(
+        from_str("#xDEADBEEF").unwrap(),
+        Value::from(0xDEAD_BEEF_u32)
+    );
+    assert_eq!(from_str("#x-23").unwrap(), Value::from(-0x23));
+    assert_eq!(from_str("#x+23").unwrap(), Value::from(0x23));
+}
+
+#[test]
+fn test_bin_numbers() {
+    assert_eq!(from_str("#b1010").unwrap(), Value::from(10));
+    assert_eq!(from_str("#b-100").unwrap(), Value::from(-4));
+    assert_eq!(from_str("#b-111").unwrap(), Value::from(-7));
+}
+
+#[test]
+fn test_oct_numbers() {
+    assert_eq!(from_str("#o0777").unwrap(), Value::from(0o777));
+    assert_eq!(from_str("#o1764").unwrap(), Value::from(0o1764));
 }
 
 #[test]

--- a/serde-lexpr/src/value/de.rs
+++ b/serde-lexpr/src/value/de.rs
@@ -47,9 +47,12 @@ macro_rules! deserialize_prim_number {
         where
             V: de::Visitor<'de>,
         {
-            self.input.as_number().ok_or_else(|| invalid_value(self.input, "a number")).and_then(|n| visit_number(n, visitor))
+            self.input
+                .as_number()
+                .ok_or_else(|| invalid_value(self.input, "a number"))
+                .and_then(|n| visit_number(n, visitor))
         }
-    }
+    };
 }
 
 impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {


### PR DESCRIPTION
The newly-understood syntax is based on R7RS, and is understood
unconditionally, although this is considered a bug; the elisp parser
options should preclude using this syntax, but there is no knob for
disabling this syntax yet.