### PR TITLE
lexpr: Make the `Parser` API more symmetric

### DIFF
--- a/lexpr-macros/src/parser.rs
+++ b/lexpr-macros/src/parser.rs
@@ -149,7 +149,7 @@ fn parse_list(tokens: TokenStream) -> Result<Value, ParseError> {
 fn parse_vector(tokens: TokenStream) -> Result<Value, ParseError> {
     let mut elements = vec![];
     let mut parser = Parser::new(tokens.into_iter().collect());
-    while let Some(_) = parser.peek() {
+    while parser.peek().is_some() {
         elements.push(parser.parse()?);
     }
     Ok(Value::Vector(elements))

--- a/lexpr/src/datum.rs
+++ b/lexpr/src/datum.rs
@@ -392,7 +392,7 @@ where
 {
     let mut parser = Parser::with_options(read, options);
     let datum = parser.expect_datum()?;
-    parser.end()?;
+    parser.expect_end()?;
 
     Ok(datum)
 }

--- a/lexpr/src/parse/tests.rs
+++ b/lexpr/src/parse/tests.rs
@@ -21,9 +21,9 @@ fn test_atoms_default() {
         Value::from(-42),
         Value::from(4.5),
     ] {
-        assert_eq!(parser.parse().unwrap(), Some(value));
+        assert_eq!(parser.expect_value().unwrap(), value);
     }
-    parser.end().unwrap();
+    parser.expect_end().unwrap();
 }
 
 #[test]
@@ -536,7 +536,7 @@ fn test_atoms_location_info() {
         assert_eq!(datum.value(), &value);
         assert_eq!(datum.span(), make_span(start, end));
     }
-    parser.end().unwrap();
+    parser.expect_end().unwrap();
 }
 
 #[test]
@@ -575,7 +575,7 @@ fn test_vector_location_info() {
             assert_eq!(make_span(start, end), element.span());
         }
     }
-    parser.end().unwrap();
+    parser.expect_end().unwrap();
 }
 
 #[test]
@@ -616,14 +616,14 @@ fn test_list_location_info() {
         }
         assert!(items.is_empty());
     }
-    parser.end().unwrap();
+    parser.expect_end().unwrap();
 }
 
 #[test]
 fn test_dotted_list_location_info() {
     let mut parser = Parser::from_str("(1 2 . 3)");
     let datum = parser.expect_datum().expect("parse error");
-    parser.end().unwrap();
+    parser.expect_end().unwrap();
     assert_eq!(datum.value(), &Value::append(vec![1, 2], 3));
     assert_eq!(datum.span(), make_span((1, 0), (1, 9)));
     let mut items = datum.list_iter().unwrap();
@@ -639,7 +639,7 @@ fn test_dotted_list_location_info() {
 fn test_quoted_location_info() {
     let mut parser = Parser::from_str("`(foo ,@bar ,baz 5)");
     let datum = parser.expect_datum().expect("parse error");
-    parser.end().unwrap();
+    parser.expect_end().unwrap();
     assert_eq!(
         datum.value(),
         &Value::list(vec![


### PR DESCRIPTION
Due to the addition of the `Datum` API, the original `Parser` method
names, especially `parse`, are now suboptimal. This change, while not
breaking API, adds a bunch of deprecations and new names, as well as
an iteration API for `Datum` values:

- Instead of calling `parse`, it is advised to use the value iteration
  API, available via `value_iter`. For `Datum`, there is its, also
  newly-added `datum_iter` counterpart. The previously-public, but
  never released, `parse_datum` method is now internal.

  `parse_datum` and `parse` can be emulated by calling
  `next().transpose()` on the respective iterators, but it is expected
  they were used for iteration (e.g. via `while let`) in the first
  place, and these iterations can now be written a bit more
  idiomatically using a for loop:

  ```rust
  for datum in parser.datum_iter() {
      let datum = datum?;
      ...
  }
  ```

  In the same vain, the `Iterator` implementation on `Parser` is now
  deprecated in favor of the `datum_iter` method; the API should not
  be overly slanted towards `Value` over `Datum`.

- `parse_value()` is now deprecated in favor of `expect_value()`. The
  new name should be make it clearer that this method will return an
  error when encountering EOF.

- Likewise, `end()` is now deprecated in favor of `expect_end()`.