### PR TITLE
lexpr-macros: Punctuation recognised as symbols

### DIFF
--- a/lexpr-macros/src/parser.rs
+++ b/lexpr-macros/src/parser.rs
@@ -1,6 +1,6 @@
 use crate::value::Value;
 
-use proc_macro2::{Delimiter, Literal, TokenStream, TokenTree};
+use proc_macro2::{Delimiter, Literal, TokenStream, TokenTree, Spacing};
 
 #[derive(Debug)]
 struct Parser {
@@ -53,7 +53,11 @@ impl Parser {
                 '#' => self.parse_octothorpe(),
                 ',' => Ok(Value::Unquoted(self.token()?.clone())),
                 '-' => Ok(Value::Negated(self.parse_literal()?)),
-                c => Err(ParseError::UnexpectedChar(c)),
+                c => match punct.spacing() {
+                    Spacing::Joint => 
+                        Ok(Value::Symbol(punct.as_char().to_string() + &self.token()?.to_string())),
+                    Spacing::Alone => Ok(Value::Symbol(punct.as_char().to_string())),
+                }
             },
             TokenTree::Literal(literal) => Ok(Value::Literal(literal.clone())),
             TokenTree::Ident(ident) => Ok(Value::Symbol(ident.to_string())),


### PR DESCRIPTION
Changed the parser to recognise unmatched punctuation as another symbol,
rather than returning an error.

This is useful when parsing sexprs for languages which are more
permissive for what they recognise as an identifier.

For example, (+ 1 2) will now properly parse, which is also a valid
expression in Common Lisp.