### PR TITLE
lexpr: Fix bug in reading square close bracket (']')

### DIFF
--- a/lexpr/src/parse/read.rs
+++ b/lexpr/src/parse/read.rs
@@ -226,7 +226,7 @@ where
     {
         loop {
             match self.peek()? {
-                Some(b' ') | Some(b'\n') | Some(b'\t') | Some(b'\r') | Some(b')') | None => {
+                Some(b' ') | Some(b'\n') | Some(b'\t') | Some(b'\r') | Some(b')') | Some(b']') | None => {
                     if scratch == b"." {
                         return error(self, ErrorCode::InvalidSymbol);
                     }
@@ -382,7 +382,7 @@ impl<'a> SliceRead<'a> {
 
         loop {
             match self.peek_byte() {
-                None | Some(b' ') | Some(b'\n') | Some(b'\t') | Some(b'\r') | Some(b')') => {
+                None | Some(b' ') | Some(b'\n') | Some(b'\t') | Some(b'\r') | Some(b')') | Some(b']') => {
                     if scratch.is_empty() {
                         // Fast path: return a slice of the raw S-expression without any
                         // copying.


### PR DESCRIPTION
When parsing expressions such as `[+ 1 2]`, the square closing bracket (`]`) is interpreted as being part of the preceding symbol &mdash; i.e. `2]` parses as a single symbol, rather than the symbol `2` and then a closing delimiter.

This pull request fixes the bug by recognizing `]` as a closing delimiter in `parse::read::IoRead::parse_symbol_bytes` and `parse::read::SliceRead::parse_symbol_bytes`.