### PR TITLE
tests: Add test for empty tuple struct, bare and in enum

### DIFF
--- a/serde-lexpr/tests/value-serde.rs
+++ b/serde-lexpr/tests/value-serde.rs
@@ -154,12 +154,26 @@ fn test_unit_struct() {
 }
 
 #[test]
+fn test_empty_tuple_struct() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Unit();
+    test_serde(&Unit(), &sexp!(#()));
+}
+
+#[test]
 fn test_newtype_struct() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct Newtype(u32);
     test_serde(&Newtype(42), &sexp!(42));
 }
 
+
+#[test]
+fn test_empty_tuple_variant() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    enum Empty { Tuplish() }
+    test_serde(&Empty::Tuplish{}, &sexp!((Tuplish)));
+}
 #[test]
 fn test_basic_struct() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]


### PR DESCRIPTION
Hi.  This MR does *not* fix the issue #60 I just reported, noir does it demonstrate it.  But it does add a missing test case.

So *this* test passes.  I think if you like the serialisation `#()` of an empty tuple struct `struct Thing ( )` then you can just merge this one commit right away.

Thanks,
Ian.

Edit 24.7 01:14 UTC: Fix brackets in empty tuple syntax in MR description and to delete text about old test case branch.