### PR TITLE
Fix serialization of empty map

### DIFF
--- a/serde-lexpr/src/value/de.rs
+++ b/serde-lexpr/src/value/de.rs
@@ -218,10 +218,11 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: de::Visitor<'de>,
     {
-        self.input
-            .as_cons()
-            .ok_or_else(|| invalid_value(self.input, "a list"))
-            .and_then(|cell| visitor.visit_map(MapAccess::new(cell)))
+        match self.input {
+            Value::Null => visitor.visit_map(MapAccess::new(None)),
+            Value::Cons(cell) => visitor.visit_map(MapAccess::new(Some(cell))),
+            _ => Err(invalid_value(self.input, "list")),
+        }
     }
 
     fn deserialize_struct<V>(
@@ -419,8 +420,8 @@ struct MapAccess<'a> {
 }
 
 impl<'a> MapAccess<'a> {
-    fn new(cell: &'a Cons) -> Self {
-        MapAccess { cursor: Some(cell) }
+    fn new(cell: Option<&'a Cons>) -> Self {
+        MapAccess { cursor: cell }
     }
 }
 

--- a/serde-lexpr/tests/value-serde.rs
+++ b/serde-lexpr/tests/value-serde.rs
@@ -167,6 +167,12 @@ fn test_newtype_struct() {
     test_serde(&Newtype(42), &sexp!(42));
 }
 
+#[test]
+fn test_empty_struct() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Unit{};
+    test_serde(&Unit{}, &sexp!(()));
+}
 
 #[test]
 fn test_empty_tuple_variant() {
@@ -174,6 +180,14 @@ fn test_empty_tuple_variant() {
     enum Empty { Tuplish() }
     test_serde(&Empty::Tuplish{}, &sexp!((Tuplish)));
 }
+
+#[test]
+fn test_empty_struct_variant() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    enum Empty { Structish{} }
+    test_serde(&Empty::Structish{}, &sexp!((Structish)));
+}
+
 #[test]
 fn test_basic_struct() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]

--- a/serde-lexpr/tests/value-serde.rs
+++ b/serde-lexpr/tests/value-serde.rs
@@ -7,6 +7,7 @@ use serde_derive::{Deserialize, Serialize};
 use lexpr::{sexp, Value};
 use serde_lexpr::{error::Category, from_str, from_value, to_value};
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 fn test_serde<T>(thing: &T, expected: &Value)
 where
@@ -60,6 +61,14 @@ fn test_hashmap() {
     test_serde(&hm, &sexp!(()));
     hm.insert("one".to_string(), 1);
     test_serde(&hm, &sexp!((("one" . 1))));
+}
+
+#[test]
+fn test_hashset() {
+    let mut hs: HashSet<String> = HashSet::new();
+    test_serde(&hs, &sexp!(()));
+    hs.insert("one".to_string());
+    test_serde(&hs, &sexp!(("one")));
 }
 
 #[test]

--- a/serde-lexpr/tests/value-serde.rs
+++ b/serde-lexpr/tests/value-serde.rs
@@ -6,6 +6,7 @@ use serde_derive::{Deserialize, Serialize};
 
 use lexpr::{sexp, Value};
 use serde_lexpr::{error::Category, from_str, from_value, to_value};
+use std::collections::HashMap;
 
 fn test_serde<T>(thing: &T, expected: &Value)
 where
@@ -51,6 +52,14 @@ fn test_vec() {
     let empty: Vec<u32> = vec![];
     test_serde(&empty, &sexp!(()));
     test_serde(&vec![1, 2, 3, 4], &sexp!((1 2 3 4)));
+}
+
+#[test]
+fn test_hashmap() {
+    let mut hm: HashMap<String, u32> = HashMap::new();
+    test_serde(&hm, &sexp!(()));
+    hm.insert("one".to_string(), 1);
+    test_serde(&hm, &sexp!((("one" . 1))));
 }
 
 #[test]

--- a/serde-lexpr/tests/value-serde.rs
+++ b/serde-lexpr/tests/value-serde.rs
@@ -154,12 +154,26 @@ fn test_unit_struct() {
 }
 
 #[test]
+fn test_empty_tuple_struct() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Unit();
+    test_serde(&Unit(), &sexp!(#()));
+}
+
+#[test]
 fn test_newtype_struct() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct Newtype(u32);
     test_serde(&Newtype(42), &sexp!(42));
 }
 
+
+#[test]
+fn test_empty_tuple_variant() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    enum Empty { Tuplish() }
+    test_serde(&Empty::Tuplish{}, &sexp!((Tuplish)));
+}
 #[test]
 fn test_basic_struct() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]


### PR DESCRIPTION
Hi.  Thanks for your sexpr work.

This small series fixes a serious bug, preventing deserialization of empty maps.  That's issue #60.  It also adds some test cases, including notably for `HashMap`.

NB there is one test case for the serialisation #() of an empty tuple struct, `struct Thing ( )`.  You might want to consider whether this is what you intended.  It seems logical to me, so I didn't make a commit to change it.

I already submitted an MR for that new test case commit - that's #61.  The first commit in that MR is in this MR too.  I hope this is OK with you and not too confusing.  If it's confusing, please close #61.