### PR TITLE
Remove the usage of proc-macro-hack

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,17 +41,17 @@ jobs:
           command: test
 
   msrv-check:
-    name: "MSRV (1.32.0) compile check"
+    name: "MSRV (1.45.0) compile check"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install 1.32 toolchain
+      - name: Install 1.45 toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.32.0 # uniform paths
+          toolchain: 1.45.0 # uniform paths
           override: true
       - name: Run cargo build
         run: cargo build

--- a/lexpr-macros/Cargo.toml
+++ b/lexpr-macros/Cargo.toml
@@ -12,5 +12,4 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0"
-proc-macro-hack = "0.5.4"
 quote = "1.0"

--- a/lexpr-macros/src/lib.rs
+++ b/lexpr-macros/src/lib.rs
@@ -3,19 +3,14 @@
 #![recursion_limit = "128"]
 #![warn(rust_2018_idioms)]
 
-// Silence clippy, as this is still needed on Rust 1.32.0.
-#[allow(unused_extern_crates)]
-extern crate proc_macro;
-
 mod generator;
 mod parser;
 mod value;
 
 use proc_macro2::TokenStream;
-use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn sexp(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let output = match expand(TokenStream::from(input)) {
         Err(e) => {

--- a/lexpr/Cargo.toml
+++ b/lexpr/Cargo.toml
@@ -18,7 +18,6 @@ fast-float-parsing = []
 [dependencies]
 itoa = "0.4.3"
 ryu = "1.0.0"
-proc-macro-hack = "0.5.4"
 lexpr-macros = { version = "0.2.0", path = "../lexpr-macros" }
 
 [dev-dependencies]

--- a/lexpr/src/lib.rs
+++ b/lexpr/src/lib.rs
@@ -257,8 +257,6 @@
 //! [Serde]: https://crates.io/crates/serde
 //! [`serde-lexpr`]: https://docs.rs/serde-lexpr
 
-use proc_macro_hack::proc_macro_hack;
-
 /// Construct a [`Value`] using syntax similar to regular S-expressions.
 ///
 /// The macro is intended to have a feeling similiar to an implicitly
@@ -342,7 +340,6 @@ use proc_macro_hack::proc_macro_hack;
 /// ```
 ///
 /// [`Value`]: enum.Value.html
-#[proc_macro_hack]
 pub use lexpr_macros::sexp;
 
 mod syntax;


### PR DESCRIPTION
This moves the MSRV up to 1.45.

Closes #78