### PR TITLE
Implement parsing Racket-style #%-prefixed symbols

### DIFF
--- a/lexpr/src/parse/tests.rs
+++ b/lexpr/src/parse/tests.rs
@@ -679,3 +679,13 @@ fn make_span(
         Position::new(end_line, end_column),
     )
 }
+
+#[test]
+fn test_racket_hash_percent_symbol() {
+    let mut parser = Parser::from_str_custom(
+        "#%symbol",
+        Options::new().with_racket_hash_percent_symbols(true),
+    );
+    assert_eq!(parser.expect_value().unwrap(), Value::symbol("#%symbol"));
+    parser.expect_end().unwrap();
+}


### PR DESCRIPTION
Per the Racket [Reader documentation, section 1.3.2](https://docs.racket-lang.org/reference/reader.html), Racket allows symbols prefixed with `#%`, with the prefix included in the symbol. This change adds a new option that allows these symbols to be parsed correctly.