### PR TITLE
lexpr: Silence clippy warning

### DIFF
--- a/lexpr/tests/print-parse.rs
+++ b/lexpr/tests/print-parse.rs
@@ -62,6 +62,7 @@ fn test_improper_lists() {
 
 #[test]
 fn test_chars_elisp() {
+    #[allow(clippy::useless_vec)] // MSRV: 1.53
     for (value, printed) in vec![
         (sexp!('x'), "?x"),
         (sexp!('\\'), "?\\\\"),


### PR DESCRIPTION
We can eliminate the `Vec` construction once we bump MSRV to 1.53.