### PR TITLE
Bump Rust edition to "2021"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,23 +29,20 @@ jobs:
         run: cargo test --all-features --all-targets
 
   msrv-check:
-    # We require at least Rust 1.45, so we can use proc macros in
-    # expression position without resorting to the `proc-macro-hack`
-    # crate.
-    name: "MSRV (1.45.0) compile check"
+    # We require at least Rust 1.56, so we can use a current version
+    # of the `proc-macro2` crate, which has an MSRV of 1.56, as of
+    # version 1.0.69.
+    name: "MSRV (1.56) compile check"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install 1.45 toolchain
-        uses: dtolnay/rust-toolchain@1.45.0
+      - name: Install 1.56 toolchain
+        uses: dtolnay/rust-toolchain@1.56
 
-      # We use the git CLI here, since otherwise cargo fails with
-      # "error reading from the zlib stream; class=Zlib (5)", see
-      # <https://github.com/rust-lang/cargo/issues/10303>.
       - name: Run cargo build
-        run: CARGO_NET_GIT_FETCH_WITH_CLI=true cargo build
+        run: cargo build
         working-directory: ./msrv-test
 
   lints:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members = [
     "lexpr-macros",
     "serde-lexpr",
 ]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# lexpr: S-expressions for Rust [![Build Status]][gh-actions] [![Codecov]][codecov] [![Rustc Version 1.45+]][rustc]
+# lexpr: S-expressions for Rust [![Build Status]][gh-actions] [![Codecov]][codecov] [![Rustc Version 1.56+]][rustc]
 
 [Build Status]: https://github.com/rotty/lexpr-rs/workflows/CI/badge.svg
 [gh-actions]: https://github.com/rotty/lexpr-rs/actions
 [codecov]: https://codecov.io/github/rotty/lexpr-rs/coverage.svg?branch=master
-[Rustc Version 1.45+]: https://img.shields.io/badge/rustc-1.45+-lightgray.svg
-[rustc]: https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html
+[Rustc Version 1.56+]: https://img.shields.io/badge/rustc-1.56+-lightgray.svg
+[rustc]: https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html
 
 This repository hosts the following crates:
 

--- a/lexpr-macros/Cargo.toml
+++ b/lexpr-macros/Cargo.toml
@@ -5,7 +5,8 @@ version = "0.2.2"
 authors = ["Andreas Rottmann <mail@r0tty.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rotty/lexpr-rs"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [lib]
 proc-macro = true

--- a/lexpr-macros/src/parser.rs
+++ b/lexpr-macros/src/parser.rs
@@ -52,9 +52,8 @@ impl Parser {
             TokenTree::Punct(punct) => match punct.as_char() {
                 '#' => self.parse_octothorpe(),
                 ',' => Ok(Value::Unquoted(self.token()?.clone())),
-                '!' | '$' | '%' | '&' | '*' | '+' | '-' | '.' | '/' | ':' | '<' | '=' | '>'
-                | '?' | '@' | '^' | '_' | '~' => {
-                    let c = punct.as_char(); // TODO: Use `@` pattern match on MSRV bump
+                c @ ('!' | '$' | '%' | '&' | '*' | '+' | '-' | '.' | '/' | ':' | '<' | '='
+                | '>' | '?' | '@' | '^' | '_' | '~') => {
                     match punct.spacing() {
                         // TODO: A lone '.' is not an identfier
                         Spacing::Joint => Ok(Value::Symbol(self.parse_identifier(c.to_string()))),

--- a/lexpr/Cargo.toml
+++ b/lexpr/Cargo.toml
@@ -9,7 +9,8 @@ readme = "README.md"
 documentation = "https://docs.rs/lexpr/"
 keywords = ["lisp", "s-expression", "sexp", "sexpr"]
 categories = ["encoding", "data-structures", "parser-implementations"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [features]
 default = ["fast-float-parsing"]

--- a/lexpr/README.md
+++ b/lexpr/README.md
@@ -1,9 +1,9 @@
-# lexpr: S-expressions for Rust [![Latest Version]][crates.io] [![Rustc Version 1.45+]][rustc]
+# lexpr: S-expressions for Rust [![Latest Version]][crates.io] [![Rustc Version 1.56+]][rustc]
 
 [Latest Version]: https://img.shields.io/crates/v/lexpr.svg
 [crates.io]: https://crates.io/crates/lexpr
-[Rustc Version 1.45+]: https://img.shields.io/badge/rustc-1.45+-lightgray.svg
-[rustc]: https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html
+[Rustc Version 1.56+]: https://img.shields.io/badge/rustc-1.56+-lightgray.svg
+[rustc]: https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html
 
 You may be looking for:
 
@@ -54,7 +54,7 @@ document.
 
 `lexpr` is CI-tested on current stable, beta and nightly channels of
 Rust. Additionally, it is made sure that the code still compiles on
-Rust 1.45.0. However, no tests are run for that build.
+Rust 1.56.0. However, no tests are run for that build.
 
 ## Supported Lisp dialects
 

--- a/lexpr/src/parse/mod.rs
+++ b/lexpr/src/parse/mod.rs
@@ -1276,9 +1276,7 @@ impl<'de, R: Read<'de>> Parser<R> {
     fn f64_from_parts(&mut self, pos: bool, significand: u64, mut exponent: i32) -> Result<f64> {
         let mut f = significand as f64;
         loop {
-            // TODO: Use `unsigned_abs` here after bumping MSRV to 1.51+.
-            #[allow(clippy::cast_abs_to_unsigned)]
-            match POW10.get(exponent.abs() as usize) {
+            match POW10.get(exponent.unsigned_abs() as usize) {
                 Some(&pow) => {
                     if exponent >= 0 {
                         f *= pow;

--- a/lexpr/tests/print-parse.rs
+++ b/lexpr/tests/print-parse.rs
@@ -62,7 +62,7 @@ fn test_improper_lists() {
 
 #[test]
 fn test_chars_elisp() {
-    for (value, printed) in vec![
+    for (value, printed) in [
         (sexp!('x'), "?x"),
         (sexp!('\\'), "?\\\\"),
         (sexp!('\u{1B}'), "?\\x1b"),

--- a/msrv-test/Cargo.toml
+++ b/msrv-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "msrv-test"
 version = "0.0.1"
 authors = ["Andreas Rottmann <a.rottmann@gmx.at>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 lexpr = { path = "../lexpr" }

--- a/serde-lexpr/Cargo.toml
+++ b/serde-lexpr/Cargo.toml
@@ -9,7 +9,8 @@ readme = "README.md"
 documentation = "https://docs.rs/serde-lexpr/"
 keywords = ["lisp", "s-expression", "sexp", "sexpr", "serde"]
 categories = ["encoding", "data-structures", "parser-implementations"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 lexpr = { version = "0.2.7", path = "../lexpr" }

--- a/serde-lexpr/README.md
+++ b/serde-lexpr/README.md
@@ -1,9 +1,9 @@
-# serde-lexpr: Serde S-expressions [![Latest Version]][crates.io] [![Rustc Version 1.45+]][rustc]
+# serde-lexpr: Serde S-expressions [![Latest Version]][crates.io] [![Rustc Version 1.56+]][rustc]
 
 [Latest Version]: https://img.shields.io/crates/v/serde-lexpr.svg
 [crates.io]: https://crates.io/crates/serde-lexpr
-[Rustc Version 1.45+]: https://img.shields.io/badge/rustc-1.45+-lightgray.svg
-[rustc]: https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html
+[Rustc Version 1.56+]: https://img.shields.io/badge/rustc-1.56+-lightgray.svg
+[rustc]: https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html
 
 You may be looking for:
 


### PR DESCRIPTION
Since the edition shipped with the Rust 1.56 toolchain, this also raises the MSRV to 1.56, which also is the first version to understand the `package.rust-version` setting, which is now present in all crates' `Cargo.toml` file.