### PR TITLE
Accept colon-prefixed keywords in `sexp` macro.

### DIFF
--- a/lexpr-macros/src/parser.rs
+++ b/lexpr-macros/src/parser.rs
@@ -72,7 +72,11 @@ impl Parser {
                                     self.eat_token();
                                     Ok(Value::Keyword(name))
                                 },
-                                Some(TokenTree::Ident(ident)) => Ok(Value::Keyword(ident.to_string())),
+                                Some(TokenTree::Ident(ident)) => {
+                                    let name = ident.to_string();
+                                    self.eat_token();
+                                    Ok(Value::Keyword(name))
+                                },
                                 _ => Ok(Value::Symbol(c.to_string())),
                             },
                             _ => Ok(Value::Symbol(c.to_string())),

--- a/lexpr-macros/src/parser.rs
+++ b/lexpr-macros/src/parser.rs
@@ -75,7 +75,6 @@ impl Parser {
                                 Some(TokenTree::Ident(ident)) => Ok(Value::Keyword(ident.to_string())),
                                 _ => Ok(Value::Symbol(c.to_string())),
                             },
-                            ':' => Ok(Value::Keyword(self.parse_identifier(String::new()))),
                             _ => Ok(Value::Symbol(c.to_string())),
                         },
                     }

--- a/lexpr-macros/src/parser.rs
+++ b/lexpr-macros/src/parser.rs
@@ -66,6 +66,7 @@ impl Parser {
                                 }
                                 _ => Ok(Value::Symbol(c.to_string())),
                             },
+                            ':' => Ok(Value::Keyword(self.parse_identifier(String::new()))),
                             _ => Ok(Value::Symbol(c.to_string())),
                         },
                     }

--- a/lexpr-macros/src/parser.rs
+++ b/lexpr-macros/src/parser.rs
@@ -66,6 +66,15 @@ impl Parser {
                                 }
                                 _ => Ok(Value::Symbol(c.to_string())),
                             },
+                            ':' => match self.peek() {
+                                Some(TokenTree::Literal(lit)) => {
+                                    let name = string_literal(lit)?;
+                                    self.eat_token();
+                                    Ok(Value::Keyword(name))
+                                },
+                                Some(TokenTree::Ident(ident)) => Ok(Value::Keyword(ident.to_string())),
+                                _ => Ok(Value::Symbol(c.to_string())),
+                            },
                             ':' => Ok(Value::Keyword(self.parse_identifier(String::new()))),
                             _ => Ok(Value::Symbol(c.to_string())),
                         },

--- a/lexpr/tests/sexp-macro.rs
+++ b/lexpr/tests/sexp-macro.rs
@@ -37,6 +37,8 @@ fn test_cons() {
         sexp! {((a . 256.0))},
         Value::list(vec![Value::cons(Value::symbol("a"), Value::from(256.0))])
     );
+    assert_eq!(sexp!((#:foo)), Value::cons(Value::keyword("foo"), Value::Null));
+    assert_eq!(sexp!((:foo)), Value::cons(Value::keyword("foo"), Value::Null));
 }
 
 #[test]

--- a/lexpr/tests/sexp-macro.rs
+++ b/lexpr/tests/sexp-macro.rs
@@ -18,6 +18,7 @@ fn test_symbols() {
 #[test]
 fn test_keywords() {
     assert_eq!(sexp!(#:foo), Value::keyword("foo"));
+    assert_eq!(sexp!(:foo), Value::keyword("foo"));
     assert_eq!(sexp!(#:"a-keyword"), Value::keyword("a-keyword"));
 }
 


### PR DESCRIPTION
Currently, the macro considers the colon character to be a separator, and so splits tokens along the boundary. 

e.g., 
`sexp!((:name "Jane Doe" :street "4026 Poe Lane"))` 
produces `(: name "Jane Doe" : street "4026 Poe Lane")`

This change allow colon-prefixed (Emacs-style) keywords (`:name` in addition to `#:name`).