### PR TITLE
serde-lexpr: Add comment notice why `to_value` is "by-value"

### DIFF
--- a/serde-lexpr/src/value/ser.rs
+++ b/serde-lexpr/src/value/ser.rs
@@ -372,6 +372,8 @@ impl ser::SerializeStructVariant for SerializeStructVariant {
 /// let val = serde_lexpr::to_value("s").unwrap();
 /// assert_eq!(val, Value::string("s"));
 /// ```
+// Taking by value is more friendly to iterator adapters, option and result
+// consumers, etc. See <https://github.com/serde-rs/json/pull/149>.
 pub fn to_value<T>(value: T) -> Result<Value>
 where
     T: ser::Serialize,


### PR DESCRIPTION
Closes #71.