### PR TITLE
Fix clippy warnings

### DIFF
--- a/lexpr/src/parse/read.rs
+++ b/lexpr/src/parse/read.rs
@@ -369,13 +369,13 @@ impl<'a> SliceRead<'a> {
         position
     }
 
-    fn parse_symbol_bytes<'s, T: ?Sized, F>(
+    fn parse_symbol_bytes<'s, T, F>(
         &'s mut self,
         scratch: &'s mut Vec<u8>,
         result: F,
     ) -> Result<Reference<'a, 's, T>>
     where
-        T: 's,
+        T: ?Sized + 's,
         F: for<'f> FnOnce(&'s Self, &'f [u8]) -> Result<&'f T>,
     {
         // Index of the first byte not yet copied into the scratch space.
@@ -486,13 +486,13 @@ impl<'a> SliceRead<'a> {
     /// The big optimization here over IoRead is that if the string contains no
     /// backslash escape sequences, the returned &str is a slice of the raw
     /// S-expression data so we avoid copying into the scratch space.
-    fn parse_r6rs_str_bytes<'s, T: ?Sized, F>(
+    fn parse_r6rs_str_bytes<'s, T, F>(
         &'s mut self,
         scratch: &'s mut Vec<u8>,
         result: F,
     ) -> Result<Reference<'a, 's, T>>
     where
-        T: 's,
+        T: ?Sized + 's,
         F: for<'f> FnOnce(&'s Self, &'f [u8]) -> Result<&'f T>,
     {
         // Index of the first byte not yet copied into the scratch space.

--- a/lexpr/src/print.rs
+++ b/lexpr/src/print.rs
@@ -198,18 +198,18 @@ pub enum VectorType {
 pub trait Formatter {
     /// Writes a representation of the special nil value to the specified writer.
     #[inline]
-    fn write_nil<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn write_nil<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         writer.write_all(b"#nil")
     }
 
     /// Writes a representation of the special nil value to the specified writer.
     #[inline]
-    fn write_null<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn write_null<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         writer.write_all(b"()")
     }
@@ -219,18 +219,18 @@ pub trait Formatter {
     /// The implementation provided by the trait will use the Scheme notation
     /// (`#t` and `#f`).
     #[inline]
-    fn write_bool<W: ?Sized>(&mut self, writer: &mut W, value: bool) -> io::Result<()>
+    fn write_bool<W>(&mut self, writer: &mut W, value: bool) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         writer.write_all(if value { b"#t" } else { b"#f" })
     }
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
-    fn write_number<W: ?Sized>(&mut self, writer: &mut W, value: &Number) -> io::Result<()>
+    fn write_number<W>(&mut self, writer: &mut W, value: &Number) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         struct Write<'a, W: io::Write + ?Sized> {
             writer: &'a mut W,
@@ -263,9 +263,9 @@ pub trait Formatter {
     ///
     /// The implementation provided by the trait will use Scheme notation
     /// (`#\C`).
-    fn write_char<W: ?Sized>(&mut self, writer: &mut W, c: char) -> io::Result<()>
+    fn write_char<W>(&mut self, writer: &mut W, c: char) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         write_scheme_char(writer, c)
     }
@@ -273,9 +273,9 @@ pub trait Formatter {
     /// Called before each series of `write_string_fragment` and
     /// `write_char_escape`.  Writes a `"` to the specified writer.
     #[inline]
-    fn begin_string<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn begin_string<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         writer.write_all(b"\"")
     }
@@ -283,9 +283,9 @@ pub trait Formatter {
     /// Called after each series of `write_string_fragment` and
     /// `write_char_escape`.  Writes a `"` to the specified writer.
     #[inline]
-    fn end_string<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn end_string<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         writer.write_all(b"\"")
     }
@@ -293,31 +293,27 @@ pub trait Formatter {
     /// Writes a string fragment that doesn't need any escaping to the specified
     /// writer.
     #[inline]
-    fn write_string_fragment<W: ?Sized>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
+    fn write_string_fragment<W>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         writer.write_all(fragment.as_bytes())
     }
 
     /// Writes a character escape code to the specified writer.
     #[inline]
-    fn write_char_escape<W: ?Sized>(
-        &mut self,
-        writer: &mut W,
-        char_escape: CharEscape,
-    ) -> io::Result<()>
+    fn write_char_escape<W>(&mut self, writer: &mut W, char_escape: CharEscape) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         write_r6rs_char_escape(writer, char_escape)
     }
 
     /// Writes a symbol to the specified writer.
     #[inline]
-    fn write_symbol<W: ?Sized>(&mut self, writer: &mut W, name: &str) -> io::Result<()>
+    fn write_symbol<W>(&mut self, writer: &mut W, name: &str) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         // TODO: We might need to escape and/or use pipe notation.
         writer.write_all(name.as_bytes())
@@ -325,9 +321,9 @@ pub trait Formatter {
 
     /// Writes a keyword to the specified writer.
     #[inline]
-    fn write_keyword<W: ?Sized>(&mut self, writer: &mut W, name: &str) -> io::Result<()>
+    fn write_keyword<W>(&mut self, writer: &mut W, name: &str) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         writer.write_all(b"#:")?;
         writer.write_all(name.as_bytes())
@@ -335,9 +331,9 @@ pub trait Formatter {
 
     /// Writes a byte vector to the specified writer.
     #[inline]
-    fn write_bytes<W: ?Sized>(&mut self, writer: &mut W, bytes: &[u8]) -> io::Result<()>
+    fn write_bytes<W>(&mut self, writer: &mut W, bytes: &[u8]) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         write_scheme_vector(self, writer, VectorType::Byte, bytes, |writer, &octet| {
             let mut buffer = itoa::Buffer::new();
@@ -348,9 +344,9 @@ pub trait Formatter {
     /// Called before any list elements.  Writes a `(` to the specified
     /// writer.
     #[inline]
-    fn begin_list<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn begin_list<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         writer.write_all(b"(")
     }
@@ -358,9 +354,9 @@ pub trait Formatter {
     /// Called after all list elements have been written.  Writes a `)` to the
     /// specified writer.
     #[inline]
-    fn end_list<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn end_list<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         writer.write_all(b")")
     }
@@ -368,9 +364,9 @@ pub trait Formatter {
     /// Called before starting to write a list or vector element. Writes a space
     /// to the specified writer, if needed.
     #[inline]
-    fn begin_seq_element<W: ?Sized>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    fn begin_seq_element<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         if first {
             Ok(())
@@ -381,9 +377,9 @@ pub trait Formatter {
 
     /// Called after every list or vector element.
     #[inline]
-    fn end_seq_element<W: ?Sized>(&mut self, _writer: &mut W) -> io::Result<()>
+    fn end_seq_element<W>(&mut self, _writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         Ok(())
     }
@@ -391,9 +387,9 @@ pub trait Formatter {
     /// Called before any vector elements.  Will write `#(` for generic vectors,
     /// or `#u8(` for byte vectors, to the specified writer.
     #[inline]
-    fn begin_vector<W: ?Sized>(&mut self, kind: VectorType, writer: &mut W) -> io::Result<()>
+    fn begin_vector<W>(&mut self, kind: VectorType, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         match kind {
             VectorType::Generic => writer.write_all(b"#("),
@@ -404,9 +400,9 @@ pub trait Formatter {
     /// Called after all vector elements have been written.  Writes a `)` to the
     /// specified writer.
     #[inline]
-    fn end_vector<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn end_vector<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         writer.write_all(b")")
     }
@@ -415,9 +411,9 @@ pub trait Formatter {
     /// generally, the `cdr` field of a cons cell.  Writes a `.` to
     /// the specified writer.
     #[inline]
-    fn write_dot<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn write_dot<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         writer.write_all(b".")
     }
@@ -437,9 +433,9 @@ pub struct CustomizedFormatter {
 }
 
 impl Formatter for CustomizedFormatter {
-    fn write_nil<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn write_nil<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         match self.options.nil_syntax {
             NilSyntax::EmptyList => writer.write_all(b"()"),
@@ -449,9 +445,9 @@ impl Formatter for CustomizedFormatter {
         }
     }
 
-    fn write_bool<W: ?Sized>(&mut self, writer: &mut W, value: bool) -> io::Result<()>
+    fn write_bool<W>(&mut self, writer: &mut W, value: bool) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         match self.options.bool_syntax {
             BoolSyntax::Symbol => writer.write_all(if value { b"t" } else { b"nil" }),
@@ -459,9 +455,9 @@ impl Formatter for CustomizedFormatter {
         }
     }
 
-    fn write_keyword<W: ?Sized>(&mut self, writer: &mut W, name: &str) -> io::Result<()>
+    fn write_keyword<W>(&mut self, writer: &mut W, name: &str) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         match self.options.keyword_syntax {
             KeywordSyntax::ColonPostfix => {
@@ -479,9 +475,9 @@ impl Formatter for CustomizedFormatter {
         }
     }
 
-    fn begin_vector<W: ?Sized>(&mut self, kind: VectorType, writer: &mut W) -> io::Result<()>
+    fn begin_vector<W>(&mut self, kind: VectorType, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         match self.options.vector_syntax {
             VectorSyntax::Brackets => writer.write_all(b"["),
@@ -496,9 +492,9 @@ impl Formatter for CustomizedFormatter {
         }
     }
 
-    fn end_vector<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn end_vector<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         match self.options.vector_syntax {
             VectorSyntax::Brackets => writer.write_all(b"]"),
@@ -506,9 +502,9 @@ impl Formatter for CustomizedFormatter {
         }
     }
 
-    fn write_char<W: ?Sized>(&mut self, writer: &mut W, c: char) -> io::Result<()>
+    fn write_char<W>(&mut self, writer: &mut W, c: char) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         match self.options.char_syntax {
             CharSyntax::R6RS => write_scheme_char(writer, c),
@@ -518,13 +514,9 @@ impl Formatter for CustomizedFormatter {
 
     /// Writes a character escape code to the specified writer.
     #[inline]
-    fn write_char_escape<W: ?Sized>(
-        &mut self,
-        writer: &mut W,
-        char_escape: CharEscape,
-    ) -> io::Result<()>
+    fn write_char_escape<W>(&mut self, writer: &mut W, char_escape: CharEscape) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         match self.options.string_syntax {
             StringSyntax::R6RS => write_r6rs_char_escape(writer, char_escape),
@@ -532,9 +524,9 @@ impl Formatter for CustomizedFormatter {
         }
     }
 
-    fn write_bytes<W: ?Sized>(&mut self, writer: &mut W, bytes: &[u8]) -> io::Result<()>
+    fn write_bytes<W>(&mut self, writer: &mut W, bytes: &[u8]) -> io::Result<()>
     where
-        W: io::Write,
+        W: io::Write + ?Sized,
     {
         match self.options.bytes_syntax {
             BytesSyntax::R6RS | BytesSyntax::R7RS => {
@@ -657,7 +649,7 @@ where
     }
 }
 
-fn write_scheme_vector<F: ?Sized, W: ?Sized, I, O>(
+fn write_scheme_vector<F, W, I, O>(
     fmt: &mut F,
     writer: &mut W,
     kind: VectorType,
@@ -665,8 +657,8 @@ fn write_scheme_vector<F: ?Sized, W: ?Sized, I, O>(
     mut output: O,
 ) -> io::Result<()>
 where
-    F: Formatter,
-    W: io::Write,
+    F: Formatter + ?Sized,
+    W: io::Write + ?Sized,
     I: IntoIterator,
     O: FnMut(&mut W, I::Item) -> io::Result<()>,
 {
@@ -705,14 +697,10 @@ where
     }
 }
 
-fn format_escaped_str<W: ?Sized, F: ?Sized>(
-    writer: &mut W,
-    formatter: &mut F,
-    value: &str,
-) -> io::Result<()>
+fn format_escaped_str<W, F>(writer: &mut W, formatter: &mut F, value: &str) -> io::Result<()>
 where
-    W: io::Write,
-    F: Formatter,
+    W: io::Write + ?Sized,
+    F: Formatter + ?Sized,
 {
     formatter.begin_string(writer)?;
     format_escaped_str_contents(writer, formatter, value)?;
@@ -720,14 +708,14 @@ where
     Ok(())
 }
 
-fn format_escaped_str_contents<W: ?Sized, F: ?Sized>(
+fn format_escaped_str_contents<W, F>(
     writer: &mut W,
     formatter: &mut F,
     value: &str,
 ) -> io::Result<()>
 where
-    W: io::Write,
-    F: Formatter,
+    W: io::Write + ?Sized,
+    F: Formatter + ?Sized,
 {
     let bytes = value.as_bytes();
 
@@ -756,9 +744,9 @@ where
     Ok(())
 }
 
-fn write_r6rs_char_escape<W: ?Sized>(writer: &mut W, char_escape: CharEscape) -> io::Result<()>
+fn write_r6rs_char_escape<W>(writer: &mut W, char_escape: CharEscape) -> io::Result<()>
 where
-    W: io::Write,
+    W: io::Write + ?Sized,
 {
     use self::CharEscape::*;
 
@@ -786,9 +774,9 @@ where
     writer.write_all(s)
 }
 
-fn write_elisp_char_escape<W: ?Sized>(writer: &mut W, char_escape: CharEscape) -> io::Result<()>
+fn write_elisp_char_escape<W>(writer: &mut W, char_escape: CharEscape) -> io::Result<()>
 where
-    W: io::Write,
+    W: io::Write + ?Sized,
 {
     use self::CharEscape::*;
 
@@ -819,9 +807,9 @@ where
     writer.write_all(s)
 }
 
-fn write_scheme_char<W: ?Sized>(writer: &mut W, c: char) -> io::Result<()>
+fn write_scheme_char<W>(writer: &mut W, c: char) -> io::Result<()>
 where
-    W: io::Write,
+    W: io::Write + ?Sized,
 {
     let n = u32::from(c);
     if (32..127).contains(&n) {
@@ -835,9 +823,9 @@ where
     }
 }
 
-fn write_elisp_char<W: ?Sized>(writer: &mut W, c: char) -> io::Result<()>
+fn write_elisp_char<W>(writer: &mut W, c: char) -> io::Result<()>
 where
-    W: io::Write,
+    W: io::Write + ?Sized,
 {
     let n = u32::from(c);
     if (32..127).contains(&n) {

--- a/serde-lexpr/src/value/ser.rs
+++ b/serde-lexpr/src/value/ser.rs
@@ -92,14 +92,14 @@ impl ser::Serializer for Serializer {
         Ok(Value::symbol(variant))
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<Value>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Value>
     where
-        T: ser::Serialize,
+        T: ser::Serialize + ?Sized,
     {
         value.serialize(self)
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &str,
         _variant_index: u32,
@@ -107,7 +107,7 @@ impl ser::Serializer for Serializer {
         value: &T,
     ) -> Result<Value>
     where
-        T: ser::Serialize,
+        T: ser::Serialize + ?Sized,
     {
         Ok(Value::cons(Value::symbol(variant), to_value(value)?))
     }
@@ -118,9 +118,9 @@ impl ser::Serializer for Serializer {
     }
 
     /// Serializes `Some` as a one-element list.
-    fn serialize_some<V: ?Sized>(self, value: &V) -> Result<Value>
+    fn serialize_some<V>(self, value: &V) -> Result<Value>
     where
-        V: ser::Serialize,
+        V: ser::Serialize + ?Sized,
     {
         Ok(Value::cons(value.serialize(self)?, Value::Null))
     }
@@ -218,9 +218,9 @@ impl ser::SerializeSeq for SerializeList {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, elem: &T) -> Result<()>
+    fn serialize_element<T>(&mut self, elem: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: ser::Serialize + ?Sized,
     {
         self.items.push(to_value(elem)?);
         Ok(())
@@ -235,9 +235,9 @@ impl ser::SerializeTuple for SerializeVector {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_element<V: ?Sized>(&mut self, value: &V) -> Result<()>
+    fn serialize_element<V>(&mut self, value: &V) -> Result<()>
     where
-        V: ser::Serialize,
+        V: ser::Serialize + ?Sized,
     {
         self.items.push(to_value(value)?);
         Ok(())
@@ -252,9 +252,9 @@ impl ser::SerializeTupleStruct for SerializeVector {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<V: ?Sized>(&mut self, value: &V) -> Result<()>
+    fn serialize_field<V>(&mut self, value: &V) -> Result<()>
     where
-        V: ser::Serialize,
+        V: ser::Serialize + ?Sized,
     {
         ser::SerializeTuple::serialize_element(self, value)
     }
@@ -268,9 +268,9 @@ impl ser::SerializeTupleVariant for SerializeTupleVariant {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<V: ?Sized>(&mut self, v: &V) -> Result<()>
+    fn serialize_field<V>(&mut self, v: &V) -> Result<()>
     where
-        V: ser::Serialize,
+        V: ser::Serialize + ?Sized,
     {
         self.items.push(to_value(v)?);
         Ok(())
@@ -288,17 +288,17 @@ impl ser::SerializeMap for SerializeMap {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<()>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: ser::Serialize + ?Sized,
     {
         self.next_key = Some(to_value(key)?);
         Ok(())
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: ser::Serialize + ?Sized,
     {
         match self.next_key.take() {
             Some(key) => self.entries.push(Value::cons(key, to_value(value)?)),
@@ -307,10 +307,10 @@ impl ser::SerializeMap for SerializeMap {
         Ok(())
     }
 
-    fn serialize_entry<K: ?Sized, V: ?Sized>(&mut self, key: &K, value: &V) -> Result<()>
+    fn serialize_entry<K, V>(&mut self, key: &K, value: &V) -> Result<()>
     where
-        K: ser::Serialize,
-        V: ser::Serialize,
+        K: ser::Serialize + ?Sized,
+        V: ser::Serialize + ?Sized,
     {
         self.entries
             .push(Value::cons(to_value(key)?, to_value(value)?));
@@ -326,9 +326,9 @@ impl ser::SerializeStruct for SerializeStruct {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<V: ?Sized>(&mut self, field: &'static str, value: &V) -> Result<()>
+    fn serialize_field<V>(&mut self, field: &'static str, value: &V) -> Result<()>
     where
-        V: ser::Serialize,
+        V: ser::Serialize + ?Sized,
     {
         self.fields
             .push(Value::cons(Value::symbol(field), to_value(value)?));
@@ -344,9 +344,9 @@ impl ser::SerializeStructVariant for SerializeStructVariant {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<V: ?Sized>(&mut self, field: &'static str, v: &V) -> Result<()>
+    fn serialize_field<V>(&mut self, field: &'static str, v: &V) -> Result<()>
     where
-        V: ser::Serialize,
+        V: ser::Serialize + ?Sized,
     {
         self.fields
             .push(Value::cons(Value::symbol(field), to_value(v)?));


### PR DESCRIPTION
clippy 0.1.78 no longer likes using multiple locations for trait bounds (lint `multiple_bound_locations`).