### PR TITLE
Allow parsing numeric-looking symbols

### DIFF
--- a/lexpr/NEWS.md
+++ b/lexpr/NEWS.md
@@ -4,6 +4,9 @@ New features:
 
 - New parser option `racket_hash_percent_symbols`, implemented in PR
   #90 by @andrew-pa.
+- New parser option `leading_digit_symbols` (PR #106). This should now
+  allow parsing files produced by recent KiCad versions, thus closing
+  #64.
 
 Changes:
 
@@ -14,9 +17,9 @@ Changes:
   octothorpe, as in Emacs Lisp and Common Lisp, allowing for a
   less-noisy spelling; e.g.: `:foo` instead of `#:foo`. Feature
   request (#99) and initial implementation (#96) by @samuel-jimenez.
-- The errors produced by the `sexp!` macro now are a bit more
-  human-oriented, as the `lexpr-macros` `ParseError` type gained a
-  `Display` implementation.
+- The `parser::Options::elisp` constructor now enables the
+  `leading_digit_symbols` option, as that's what's appropriate for
+  Emacs Lisp.
 
 Maintenance-related changes:
 

--- a/lexpr/README.md
+++ b/lexpr/README.md
@@ -98,6 +98,12 @@ a feature that is not yet listed here, please [file an issue]!.
 - Integer literals with an arbitrary base (radix), are not yet
   supported.
 
+### KiCad
+
+- Since version 0.3.0, reading and writing S-expression files produced
+  by recent versions of KiCad should be supported given the new
+  `with_leading_digit_symbols` parser option.
+
 ## Licensing
 
 The code and documentation in the `lexpr` crate is [free

--- a/lexpr/src/parse/tests.rs
+++ b/lexpr/src/parse/tests.rs
@@ -689,3 +689,23 @@ fn test_racket_hash_percent_symbol() {
     assert_eq!(parser.expect_value().unwrap(), Value::symbol("#%symbol"));
     parser.expect_end().unwrap();
 }
+
+fn parser_recognizes_digit_symbols(options: Options) {
+    let mut parser = Parser::from_str_custom("55033ea4-52b5-46f6-b909-193ee90f64f8 1234", options);
+    assert_eq!(
+        parser.expect_value().unwrap(),
+        Value::symbol("55033ea4-52b5-46f6-b909-193ee90f64f8")
+    );
+    assert_eq!(parser.expect_value().unwrap(), Value::from(1234));
+    parser.expect_end().unwrap();
+}
+
+#[test]
+fn test_digit_symbols() {
+    parser_recognizes_digit_symbols(Options::new().with_leading_digit_symbols(true));
+}
+
+#[test]
+fn test_digit_symbols_elisp() {
+    parser_recognizes_digit_symbols(Options::elisp());
+}


### PR DESCRIPTION
Note that we may want to extend general symbol syntax support as well, on both parsing and printing, which is currently lacking (at least):

- R6RS/R7RS hex escapes
- R7RS pipe-quoted symbols
- Emacs Lisp escapes