### PR TITLE
Revert accidental bump of `lexpr-macros` version

### DIFF
--- a/lexpr-macros/Cargo.toml
+++ b/lexpr-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lexpr-macros"
 description = "Internal crate implementing macros exposed by the `lexpr` crate"
-version = "0.2.4"
+version = "0.2.3"
 authors = ["Andreas Rottmann <mail@r0tty.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rotty/lexpr-rs"

--- a/lexpr/Cargo.toml
+++ b/lexpr/Cargo.toml
@@ -20,11 +20,11 @@ sexp-macro = ["lexpr-macros"] # MSRV 1.60+: use the `dep:` prefix here
 [dependencies]
 itoa = "1.0"
 ryu = "1.0.0"
-lexpr-macros = { version = "0.2.4", path = "../lexpr-macros", optional = true }
+lexpr-macros = { version = "0.2.3", path = "../lexpr-macros", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
-lexpr-macros = { version = "0.2.4", path = "../lexpr-macros" }
+lexpr-macros = { version = "0.2.3", path = "../lexpr-macros" }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 rand = "0.8.1"


### PR DESCRIPTION
Version `0.2.3` was not yet released, so use that as version for the next release.