### PR TITLE
Add custom `Drop` implementation for `Cons`

### DIFF
--- a/lexpr/NEWS.md
+++ b/lexpr/NEWS.md
@@ -8,6 +8,12 @@ New features:
   allow parsing files produced by recent KiCad versions, thus closing
   #64.
 
+Fixes:
+
+- The `Cons` type now has a custom `Drop` implementation which avoids
+  recursion on the "cdr" field. This allows for dropping long lists
+  without overflowing the stack (#104).
+
 Changes:
 
 - The `sexp!` macro is now only included when specifying the

--- a/lexpr/src/value/tests.rs
+++ b/lexpr/src/value/tests.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(tarpaulin, skip)]
 
+use std::iter;
+
 use crate::{Cons, Number, Value};
 
 type Predicate = fn(&Value) -> bool;
@@ -135,4 +137,9 @@ fn test_vectors() {
         check_type_predicates(&v, "vector");
         assert_eq!(v.as_slice(), Some(elts.as_slice()));
     }
+}
+
+#[test]
+fn drop_long_list() {
+    let _long = Value::list(iter::repeat(Value::from(42)).take(1_000_000));
 }


### PR DESCRIPTION
This avoids stack overflow when dropping long lists. Closes #104.