### PR TITLE
lexpr: Symbols may start with any "alphabetic" unicode codepoint

### DIFF
--- a/lexpr/NEWS.md
+++ b/lexpr/NEWS.md
@@ -7,6 +7,8 @@ New features:
 - New parser option `leading_digit_symbols` (PR #106). This should now
   allow parsing files produced by recent KiCad versions, thus closing
   #64.
+- Accept symbols starting with an alphabetical unicode codepoint,
+  fixing #112.
 
 Fixes:
 

--- a/lexpr/src/parse/read.rs
+++ b/lexpr/src/parse/read.rs
@@ -1185,7 +1185,7 @@ static DELIMITER: [u8; 12] = [
 
 /// Decode a UTF8 multibyte sequence starting with `initial` and return the
 /// decoded codepoint.
-fn decode_utf8_sequence<'de, R: Read<'de> + ?Sized>(
+pub(crate) fn decode_utf8_sequence<'de, R: Read<'de> + ?Sized>(
     read: &mut R,
     scratch: &mut Vec<u8>,
     initial: u8,

--- a/lexpr/src/tests.rs
+++ b/lexpr/src/tests.rs
@@ -54,12 +54,12 @@ fn gen_value(g: &mut Gen, depth: usize) -> Value {
         }
         Symbol => {
             let choices = [
-                "foo", "a-symbol", "$?:!", "+", "+foo", "-", "-foo", "..", ".foo",
+                "foo", "a-symbol", "$?:!", "+", "+foo", "-", "-foo", "..", ".foo", "λ-1",
             ];
             Value::symbol(*g.choose(&choices).unwrap())
         }
         Keyword => {
-            let choices = ["foo", "a-keyword", "$?:!"];
+            let choices = ["foo", "a-keyword", "$?:!", "λ-2"];
             Value::keyword(*g.choose(&choices).unwrap())
         }
         Bytes => {

--- a/lexpr/tests/print-parse.rs
+++ b/lexpr/tests/print-parse.rs
@@ -70,6 +70,11 @@ fn test_unicode_chars() {
 }
 
 #[test]
+fn test_leading_unicode_symbols() {
+    check_roundtrip_default(Value::Symbol("λ-test-ω".into()), "λ-test-ω");
+}
+
+#[test]
 fn test_chars_elisp() {
     for (value, printed) in [
         (sexp!('x'), "?x"),


### PR DESCRIPTION
Fixes #112.