### PR TITLE
Explicitly expose deserialiser

### DIFF
--- a/serde-lexpr/src/de.rs
+++ b/serde-lexpr/src/de.rs
@@ -1,3 +1,5 @@
+//! Deserialize lexprs
+
 use std::io;
 
 use serde::de::DeserializeOwned;

--- a/serde-lexpr/src/lib.rs
+++ b/serde-lexpr/src/lib.rs
@@ -147,9 +147,9 @@
 //! [Serde]: https://crates.io/crates/serde
 //! [`lexpr::Value`]: https://docs.rs/lexpr/*/lexpr/enum.Value.html
 
-mod de;
-mod ser;
-mod value;
+pub mod de;
+pub mod ser;
+pub mod value;
 
 pub mod error;
 pub use de::{

--- a/serde-lexpr/src/ser.rs
+++ b/serde-lexpr/src/ser.rs
@@ -1,3 +1,5 @@
+//! Serialize lexprs
+
 use serde::Serialize;
 
 use lexpr::print;

--- a/serde-lexpr/src/value/de.rs
+++ b/serde-lexpr/src/value/de.rs
@@ -11,6 +11,7 @@ use crate::error::{Error, Result};
 use crate::Value;
 
 /// lexpr deserializer
+#[derive(Copy, Clone, Debug)]
 pub struct Deserializer<'de> {
     input: &'de Value,
 }

--- a/serde-lexpr/src/value/de.rs
+++ b/serde-lexpr/src/value/de.rs
@@ -1,3 +1,5 @@
+//! Internal deserialization code
+
 use std::marker::PhantomData;
 
 use serde::de::{self, Error as SerdeError, Visitor};
@@ -8,11 +10,13 @@ use lexpr::{number, Cons, Number};
 use crate::error::{Error, Result};
 use crate::Value;
 
+/// lexpr deserializer
 pub struct Deserializer<'de> {
     input: &'de Value,
 }
 
 impl<'de> Deserializer<'de> {
+    /// Create new deserializer from a value
     pub fn from_value(input: &'de Value) -> Self {
         Deserializer { input }
     }

--- a/serde-lexpr/src/value/mod.rs
+++ b/serde-lexpr/src/value/mod.rs
@@ -5,5 +5,5 @@ pub use lexpr::{Cons, Value};
 pub use de::from_value;
 pub use ser::to_value;
 
-mod de;
-mod ser;
+pub mod de;
+pub mod ser;

--- a/serde-lexpr/src/value/ser.rs
+++ b/serde-lexpr/src/value/ser.rs
@@ -5,6 +5,7 @@ use serde::ser;
 use crate::error::{Error, Result};
 use crate::Value;
 
+/// Value serializer
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {


### PR DESCRIPTION
For my crate [`seismon`](https://github.com/eira-fransham/seismon), I wanted to parse s-expressions for variables and console parameters. The main issue with this, is that for some custom parsing code I needed access to the name of `serde-lexpr`'s `Deserializer` type, see [here](https://github.com/eira-fransham/seismon/blob/69c410f6149874e7ba58ee7c35070ee544db8c5f/src/common/console/mod.rs#L1162-L1228).

While I don't really have a big issue with continuing to maintain a fork for my usecase (and I might move away from S-expressions altogether), I thought I'd at least make an effort to upstream my changes just in case they're desired. The documentation in this PR is unfinished, if there's potential to get these API changes upstreamed then I'll polish it up to a releasable standard but if you want to avoid increasing the API surface then I won't bother improving the docs and just continue to maintain it as a fork.